### PR TITLE
Correct localization message that erroneously indicates a gold reward is a chivalry reward

### DIFF
--- a/Localization/en.json
+++ b/Localization/en.json
@@ -13503,7 +13503,7 @@
   "dungeon.wounded_choice": "(H)elp him, (R)ob him, or (L)eave him? ",
   "dungeon.wounded_heal_potion": "You use a healing potion on the wounded stranger.",
   "dungeon.wounded_recovers": "He recovers enough to stand.",
-  "dungeon.wounded_reward": "Your chivalry increases by {0}!",
+  "dungeon.wounded_reward": "He gratefully rewards you with {0} gold coins!",
   "dungeon.wounded_bandage": "You try to bandage his wounds with cloth...",
   "dungeon.wounded_helps": "It seems to help a little.",
   "dungeon.wounded_dies": "Unfortunately, he dies from his wounds.",

--- a/Localization/es.json
+++ b/Localization/es.json
@@ -13033,7 +13033,7 @@
   "dungeon.wounded_choice": "a(Y)udarlo, (R)obarlo, o (D)ejarlo? ",
   "dungeon.wounded_heal_potion": "Usas una poción de curación en el extraño herido.",
   "dungeon.wounded_recovers": "Se recupera lo suficiente para ponerse de pie.",
-  "dungeon.wounded_reward": "Tu caballerosidad aumenta en {0}!",
+  "dungeon.wounded_reward": "Él te recompensa con gratitud con {0} monedas de oro!",
   "dungeon.wounded_bandage": "Intentas vendar sus heridas con tela...",
   "dungeon.wounded_helps": "Parece ayudar un poco.",
   "dungeon.wounded_dies": "Desafortunadamente, muere por sus heridas.",

--- a/Localization/hu.json
+++ b/Localization/hu.json
@@ -13455,7 +13455,7 @@
     "dungeon.wounded_choice":  "(S)egítesz rajta, (K)irabolod, vagy (T)ovábblépsz? ",
     "dungeon.wounded_heal_potion":  "Gyógyitalt töltesz a sebesült idegen torkába.",
     "dungeon.wounded_recovers":  "Visszatér belé az élet, s lábra áll.",
-    "dungeon.wounded_reward":  "Lovagiasságod {0} ponttal növekedett!",
+    "dungeon.wounded_reward":  "Hálásan megjutalmaz {0} aranyérmével!",
     "dungeon.wounded_bandage":  "Megpróbálod vászonnal bekötni sebeit...",
     "dungeon.wounded_helps":  "Úgy tűnik, némi enyhülést hoztál számára.",
     "dungeon.wounded_dies":  "Sajnos az élet elszállt belőle, sebei túl mélyek voltak.",

--- a/Localization/it.json
+++ b/Localization/it.json
@@ -13022,7 +13022,7 @@
   "dungeon.wounded_choice": "(A)iutarlo, (D)erubarlo, o (L)asciarlo? ",
   "dungeon.wounded_heal_potion": "Usi una pozione curativa sullo straniero ferito.",
   "dungeon.wounded_recovers": "Si riprende abbastanza da alzarsi in piedi.",
-  "dungeon.wounded_reward": "La tua cavalleria aumenta di {0}!",
+  "dungeon.wounded_reward": "Ti ricompensa con gratitudine con {0} monete d'oro!",
   "dungeon.wounded_bandage": "Cerchi di fasciare le sue ferite con della stoffa...",
   "dungeon.wounded_helps": "Sembra aiutare un poco.",
   "dungeon.wounded_dies": "Sfortunatamente, muore per le sue ferite.",


### PR DESCRIPTION
As I was playing, I noticed that in the event you encounter a wounded man and help him, there was a confusing message about chivalry gain in the multiple thousands. Checking [DungeonLocation.cs#L7607](https://github.com/binary-knight/usurper-reborn/blob/6630f82937139b40d8c05951c1a290d150e4be79/Scripts/Locations/DungeonLocation.cs#L7607), I found that the reward is actually a gold reward. So here are proposed localization changes to clarify that.

The non-English strings were produced with Google Translate from the English string.