### PR TITLE
Fix Magic Shop's max healing potion calculation and localization

### DIFF
--- a/Scripts/Locations/MagicShopLocation.cs
+++ b/Scripts/Locations/MagicShopLocation.cs
@@ -561,7 +561,7 @@ public partial class MagicShopLocation : BaseLocation
         long potionPrice = ApplyAllPriceModifiers(player.Level * GameConfig.HealingPotionLevelMultiplier, player);
         var (_, _, hpPotionUnitWithTax) = CityControlSystem.CalculateTaxedPrice(potionPrice);
         int maxPotionsCanBuy = hpPotionUnitWithTax > 0 ? (int)(player.Gold / hpPotionUnitWithTax) : 0;
-        int maxPotionsCanCarry = GameConfig.MaxHealingPotions - (int)player.Healing;
+        int maxPotionsCanCarry = player.MaxPotions - (int)player.Healing;
         int maxPotions = Math.Min(maxPotionsCanBuy, maxPotionsCanCarry);
 
         if (player.Gold < hpPotionUnitWithTax)
@@ -584,7 +584,7 @@ public partial class MagicShopLocation : BaseLocation
 
         DisplayMessage(Loc.Get("magic_shop.potion_price", $"{potionPrice:N0}"), "gray");
         DisplayMessage(Loc.Get("magic_shop.potion_gold", $"{player.Gold:N0}"), "gray");
-        DisplayMessage(Loc.Get("magic_shop.potion_current", $"{player.Healing}"), "gray");
+        DisplayMessage(Loc.Get("magic_shop.potion_current", $"{player.Healing}", $"{player.MaxPotions}"), "gray");
         DisplayMessage("");
 
         DisplayMessage(Loc.Get("magic_shop.potion_how_many", $"{maxPotions}"), "yellow", false);
@@ -604,7 +604,7 @@ public partial class MagicShopLocation : BaseLocation
                 // Process city tax share from this sale
                 CityControlSystem.Instance.ProcessSaleTax(totalCost);
 
-                DisplayMessage(Loc.Get("magic_shop.potion_deal", $"{quantity}"), "green");
+                DisplayMessage(Loc.Get("magic_shop.potion_deal", "Ravanella", $"{quantity}"), "green");
                 DisplayMessage(Loc.Get("magic_shop.potion_total", $"{hpTotalWithTax:N0}"), "gray");
 
                 player.Statistics?.RecordGoldSpent(hpTotalWithTax);


### PR DESCRIPTION
Found three bugs when buying healing potions at the magic shop:

1. The "max carry" limit was set to the game-configured maximum rather than the player's maximum dictated by their level like when purchasing healing potions from the monk in the dungeon (e.g. https://github.com/binary-knight/usurper-reborn/blob/6630f82937139b40d8c05951c1a290d150e4be79/Scripts/Locations/DungeonLocation.cs#L10471)

2. There was a missing argument to the potion counter localization string.

3. Another missing localization argument when the deal is concluded.