### PR TITLE
Centralize XP formula in GameConfig and remove duplicates

### DIFF
--- a/Scripts/Core/GameConfig.cs
+++ b/Scripts/Core/GameConfig.cs
@@ -1201,13 +1201,31 @@ public static partial class GameConfig
     public const int SessionXPDiminishMessageInterval = 10;     // Show fatigue message every N combats
 
     /// <summary>
+    /// Canonical XP formula. Cumulative experience required to reach <paramref name="level"/>.
+    /// Late-game exponent steepens to 2.25 above level 50.
+    /// </summary>
+    public static long GetExperienceForLevel(int level)
+    {
+        if (level <= 1) return 0;
+        long exp = 0;
+        for (int i = 2; i <= level; i++)
+        {
+            double exponent = i <= 50 ? 2.0 : 2.25;
+            exp += (long)(Math.Pow(i, exponent) * 50);
+        }
+        return exp;
+    }
+
+    /// <summary>
     /// Get the session XP threshold for a given player level.
     /// Scales with level so higher-level players can earn proportionally more XP per session.
     /// At level 10: 100,000. At level 50: 1,040,400. At level 89: 3,240,000. At level 100: 4,080,400.
     /// </summary>
     public static long GetSessionXPThreshold(int level)
     {
-        long nextLevelXP = (long)(Math.Pow(level + 1, 2.0) * 50);
+        int l = level + 1;
+        double exponent = l <= 50 ? 2.0 : 2.25;
+        long nextLevelXP = (long)(Math.Pow(l, exponent) * 50);
         return Math.Max(SessionXPDiminishBaseThreshold, nextLevelXP * 8);
     }
     // Study / Library

--- a/Scripts/Core/GameEngine.cs
+++ b/Scripts/Core/GameEngine.cs
@@ -6158,7 +6158,7 @@ public partial class GameEngine
 
             // Fix Experience if it's too low for the NPC's level — legacy saves may not have
             // tracked NPC XP, or GenerateNPCStats may have used template.StartLevel instead of actual Level
-            long expectedMinXP = GetExperienceForNPCLevel(npc.Level);
+            long expectedMinXP = GameConfig.GetExperienceForLevel(npc.Level);
             if (npc.Experience < expectedMinXP && npc.Level > 1)
             {
                 npc.Experience = expectedMinXP;
@@ -6515,21 +6515,6 @@ public partial class GameEngine
                 $"Fixed corrupted base stats for {npc.Name} (Level {level} {npc.ClassName}): " +
                 $"STR={npc.BaseStrength}, DEF={npc.BaseDefence}, AGI={npc.BaseAgility}");
         }
-    }
-
-    /// <summary>
-    /// XP formula matching the player's curve (level^2.0 * 50)
-    /// Used to initialize NPC XP when loading legacy saves
-    /// </summary>
-    private static long GetExperienceForNPCLevel(int level)
-    {
-        if (level <= 1) return 0;
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            exp += (long)(Math.Pow(i, 2.0) * 50);
-        }
-        return exp;
     }
 
     /// <summary>

--- a/Scripts/Core/NPC.cs
+++ b/Scripts/Core/NPC.cs
@@ -290,7 +290,7 @@ public partial class NPC : Character
         Gold = GetBaseGold(archetype) * level;
 
         // Set experience
-        Experience = GetExperienceForLevel(level);
+        Experience = GameConfig.GetExperienceForLevel(level);
 
         // Save base stats so RecalculateStats() works correctly
         BaseStrength = Strength;
@@ -392,23 +392,6 @@ public partial class NPC : Character
         Age = 18 + Level + Random.Shared.Next(-5, 11);
         if (Age < 18) Age = 18;
         if (Age > 80) Age = 80;
-    }
-    
-    /// <summary>
-    /// Get experience needed for a specific level (Pascal compatible)
-    /// </summary>
-    private long GetExperienceForLevel(int level)
-    {
-        if (level <= 1) return 0;
-        
-        // Experience formula compatible with Pascal
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            // Softened curve: level^2.0 * 50 (rebalanced v0.41.4)
-            exp += (long)(Math.Pow(i, 2.0) * 50);
-        }
-        return exp;
     }
     
     /// <summary>

--- a/Scripts/Locations/BaseLocation.cs
+++ b/Scripts/Locations/BaseLocation.cs
@@ -2021,8 +2021,8 @@ public abstract class BaseLocation
             if (currentPlayer.Level < GameConfig.MaxLevel)
             {
                 long currentXP = currentPlayer.Experience;
-                long nextLevelXP = GetExperienceForLevel(currentPlayer.Level + 1);
-                long prevLevelXP = GetExperienceForLevel(currentPlayer.Level);
+                long nextLevelXP = GameConfig.GetExperienceForLevel(currentPlayer.Level + 1);
+                long prevLevelXP = GameConfig.GetExperienceForLevel(currentPlayer.Level);
                 long xpIntoLevel = currentXP - prevLevelXP;
                 long xpNeeded = nextLevelXP - prevLevelXP;
                 int xpPercent = xpNeeded > 0 ? (int)((xpIntoLevel * 100) / xpNeeded) : 0;
@@ -2084,8 +2084,8 @@ public abstract class BaseLocation
             if (currentPlayer.Level < GameConfig.MaxLevel)
             {
                 long currentXP = currentPlayer.Experience;
-                long nextLevelXP = GetExperienceForLevel(currentPlayer.Level + 1);
-                long prevLevelXP = GetExperienceForLevel(currentPlayer.Level);
+                long nextLevelXP = GameConfig.GetExperienceForLevel(currentPlayer.Level + 1);
+                long prevLevelXP = GameConfig.GetExperienceForLevel(currentPlayer.Level);
                 long xpIntoLevel = currentXP - prevLevelXP;
                 long xpNeeded = nextLevelXP - prevLevelXP;
                 int xpPercent = xpNeeded > 0 ? (int)((xpIntoLevel * 100) / xpNeeded) : 0;
@@ -2105,20 +2105,6 @@ public abstract class BaseLocation
 
         // Quick command bar
         ShowQuickCommandBar();
-    }
-
-    /// <summary>
-    /// Experience required to have the specified level (cumulative)
-    /// </summary>
-    private static long GetExperienceForLevel(int level)
-    {
-        if (level <= 1) return 0;
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            exp += (long)(Math.Pow(i, 2.0) * 50);
-        }
-        return exp;
     }
 
     /// <summary>
@@ -2321,8 +2307,8 @@ public abstract class BaseLocation
         if (currentPlayer.Level < GameConfig.MaxLevel)
         {
             long curXP = currentPlayer.Experience;
-            long nextXP = GetExperienceForLevel(currentPlayer.Level + 1);
-            long prevXP = GetExperienceForLevel(currentPlayer.Level);
+            long nextXP = GameConfig.GetExperienceForLevel(currentPlayer.Level + 1);
+            long prevXP = GameConfig.GetExperienceForLevel(currentPlayer.Level);
             long xpInto = curXP - prevXP;
             long xpNeed = nextXP - prevXP;
             int pct = xpNeed > 0 ? (int)((xpInto * 100) / xpNeed) : 0;
@@ -5647,7 +5633,7 @@ public abstract class BaseLocation
         terminal.WriteLine($"{currentPlayer.Experience:N0}");
 
         // Calculate XP needed for next level
-        long nextLevelXP = GetExperienceForLevel(currentPlayer.Level + 1);
+        long nextLevelXP = GameConfig.GetExperienceForLevel(currentPlayer.Level + 1);
         long xpNeeded = nextLevelXP - currentPlayer.Experience;
 
         terminal.SetColor("white");

--- a/Scripts/Locations/DungeonLocation.cs
+++ b/Scripts/Locations/DungeonLocation.cs
@@ -2526,7 +2526,7 @@ public class DungeonLocation : BaseLocation
         // Line 6: Level eligibility
         if (player != null && player.Level < GameConfig.MaxLevel)
         {
-            long experienceNeeded = GetExperienceForLevel(player.Level + 1);
+            long experienceNeeded = GameConfig.GetExperienceForLevel(player.Level + 1);
             if (player.Experience >= experienceNeeded)
             {
                 terminal.SetColor("bright_green");
@@ -3547,7 +3547,7 @@ public class DungeonLocation : BaseLocation
         if (currentPlayer == null || currentPlayer.Level >= GameConfig.MaxLevel)
             return;
 
-        long experienceNeeded = GetExperienceForLevel(currentPlayer.Level + 1);
+        long experienceNeeded = GameConfig.GetExperienceForLevel(currentPlayer.Level + 1);
 
         if (currentPlayer.Experience >= experienceNeeded)
         {
@@ -3555,20 +3555,6 @@ public class DungeonLocation : BaseLocation
             WriteBoxHeader(Loc.Get("dungeon.level_raise"), "bright_yellow");
             terminal.WriteLine("");
         }
-    }
-
-    /// <summary>
-    /// Experience required to have the specified level (cumulative)
-    /// </summary>
-    private static long GetExperienceForLevel(int level)
-    {
-        if (level <= 1) return 0;
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            exp += (long)(Math.Pow(i, 2.0) * 50);
-        }
-        return exp;
     }
 
     protected override string GetBreadcrumbPath()

--- a/Scripts/Locations/LevelMasterLocation.cs
+++ b/Scripts/Locations/LevelMasterLocation.cs
@@ -1275,23 +1275,7 @@ public class LevelMasterLocation : BaseLocation
     /// </summary>
     public static long GetExperienceForLevel(int level)
     {
-        if (level <= 1) return 0;
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            // Softened curve: level^2.0 * 50 (rebalanced v0.41.4)
-            // Late-game tuning: above level 50 the exponent steepens to 2.25,
-            // so each level beyond 50 costs progressively more XP relative to
-            // monster XP rewards (which scale ^1.5). Closes the gap that let
-            // dedicated players reach Lv.100 in ~12-15 hours of focused play.
-            // Existing characters retain their Level field; CheckAutoLevelUp
-            // only levels UP, never DOWN, so nobody de-levels on deploy --
-            // they just take longer to reach the next level. Below 50, curve
-            // is unchanged so new players don't see any difference.
-            double exponent = i <= 50 ? 2.0 : 2.25;
-            exp += (long)(Math.Pow(i, exponent) * 50);
-        }
-        return exp;
+        return GameConfig.GetExperienceForLevel(level);
     }
 
     /// <summary>

--- a/Scripts/Locations/MainStreetLocation.cs
+++ b/Scripts/Locations/MainStreetLocation.cs
@@ -547,8 +547,8 @@ public class MainStreetLocation : BaseLocation
         if (currentPlayer.Level < GameConfig.MaxLevel)
         {
             long curXP = currentPlayer.Experience;
-            long nextXP = GetExperienceForLevel(currentPlayer.Level + 1);
-            long prevXP = GetExperienceForLevel(currentPlayer.Level);
+            long nextXP = GameConfig.GetExperienceForLevel(currentPlayer.Level + 1);
+            long prevXP = GameConfig.GetExperienceForLevel(currentPlayer.Level);
             long xpInto = curXP - prevXP;
             long xpNeed = nextXP - prevXP;
             int pct = xpNeed > 0 ? (int)((xpInto * 100) / xpNeed) : 0;
@@ -670,7 +670,7 @@ public class MainStreetLocation : BaseLocation
         if (currentPlayer.Level >= GameConfig.MaxLevel)
             return;
 
-        long experienceNeeded = GetExperienceForLevel(currentPlayer.Level + 1);
+        long experienceNeeded = GameConfig.GetExperienceForLevel(currentPlayer.Level + 1);
 
         if (currentPlayer.Experience >= experienceNeeded)
         {
@@ -691,21 +691,6 @@ public class MainStreetLocation : BaseLocation
             }
             terminal.WriteLine("");
         }
-    }
-
-    /// <summary>
-    /// Experience required to have the specified level (cumulative)
-    /// </summary>
-    private static long GetExperienceForLevel(int level)
-    {
-        if (level <= 1) return 0;
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            // Softened curve: level^2.0 * 50 (rebalanced v0.41.4)
-            exp += (long)(Math.Pow(i, 2.0) * 50);
-        }
-        return exp;
     }
 
     /// <summary>

--- a/Scripts/Systems/CombatEngine.cs
+++ b/Scripts/Systems/CombatEngine.cs
@@ -24954,7 +24954,7 @@ public partial class CombatEngine
             // Award XP
             long previousXP = teammate.Experience;
             teammate.Experience += teammateXP;
-            long xpNeeded = GetExperienceForLevel(teammate.Level + 1);
+            long xpNeeded = GameConfig.GetExperienceForLevel(teammate.Level + 1);
 
             // Show XP gain for all teammates (with catch-up indicator)
             terminal.SetColor("cyan");
@@ -24963,7 +24963,7 @@ public partial class CombatEngine
             terminal.SetColor("white");
 
             // Check for level up (using same formula as player/NPCs)
-            long xpForNextLevel = GetExperienceForLevel(teammate.Level + 1);
+            long xpForNextLevel = GameConfig.GetExperienceForLevel(teammate.Level + 1);
             while (teammate.Experience >= xpForNextLevel && teammate.Level < 100)
             {
                 // Snapshot stats before this level's gains
@@ -25002,7 +25002,7 @@ public partial class CombatEngine
                 NewsSystem.Instance?.Newsy(true, $"{teammate.DisplayName} has achieved Level {teammate.Level}!");
 
                 // Calculate next threshold
-                xpForNextLevel = GetExperienceForLevel(teammate.Level + 1);
+                xpForNextLevel = GameConfig.GetExperienceForLevel(teammate.Level + 1);
             }
 
             // Sync changes to canonical ActiveNPCs entry (handles orphaned references)
@@ -25066,12 +25066,12 @@ public partial class CombatEngine
             {
                 // NPC teammate — award directly and check level-up
                 teammate.Experience += slotXP;
-                long xpNeeded = GetExperienceForLevel(teammate.Level + 1);
+                long xpNeeded = GameConfig.GetExperienceForLevel(teammate.Level + 1);
                 terminal.SetColor("cyan");
                 terminal.WriteLine($"  {teammate.DisplayName} ({percent}%): +{slotXP} XP ({teammate.Experience:N0}/{xpNeeded:N0}){catchUpLabel}");
 
                 // Check for level up
-                long xpForNextLevel = GetExperienceForLevel(teammate.Level + 1);
+                long xpForNextLevel = GameConfig.GetExperienceForLevel(teammate.Level + 1);
                 while (teammate.Experience >= xpForNextLevel && teammate.Level < 100)
                 {
                     long bHP = teammate.BaseMaxHP; long bStr = teammate.BaseStrength; long bDef = teammate.BaseDefence;
@@ -25100,7 +25100,7 @@ public partial class CombatEngine
                     if (sc.Count > 0) terminal.WriteLine($"    {string.Join("  ", sc)}");
 
                     NewsSystem.Instance?.Newsy(true, $"{teammate.DisplayName} has achieved Level {teammate.Level}!");
-                    xpForNextLevel = GetExperienceForLevel(teammate.Level + 1);
+                    xpForNextLevel = GameConfig.GetExperienceForLevel(teammate.Level + 1);
                 }
 
                 // Sync changes to canonical ActiveNPCs entry — if the world sim rebuilt
@@ -25180,20 +25180,6 @@ public partial class CombatEngine
         canonical.RecalculateStats();
 
         DebugLogger.Instance.LogInfo("COMBAT", $"Synced orphaned NPC teammate {npcTeammate.DisplayName} (Lv {canonical.Level}) back to ActiveNPCs");
-    }
-
-    /// <summary>
-    /// XP formula matching the player's curve (level^2.0 * 50)
-    /// </summary>
-    private static long GetExperienceForLevel(int level)
-    {
-        if (level <= 1) return 0;
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            exp += (long)(Math.Pow(i, 2.0) * 50);
-        }
-        return exp;
     }
 
     // v0.57.13: returns (totalSwings, windfuryProcced). Callers that route main-hand/off-hand

--- a/Scripts/Systems/CompanionSystem.cs
+++ b/Scripts/Systems/CompanionSystem.cs
@@ -1601,7 +1601,7 @@ namespace UsurperRemake.Systems
                 companion.DisabledAbilities.Clear();
                 companion.DisabledSpells.Clear();
                 companion.Level = Math.Max(1, companion.RecruitLevel + 5);
-                companion.Experience = GetExperienceForLevel(companion.Level);
+                companion.Experience = GameConfig.GetExperienceForLevel(companion.Level);
             }
 
             activeCompanions.Clear();
@@ -1668,7 +1668,7 @@ namespace UsurperRemake.Systems
                     }
                     else
                     {
-                        companion.Experience = GetExperienceForLevel(companion.Level);
+                        companion.Experience = GameConfig.GetExperienceForLevel(companion.Level);
                         // DebugLogger: Initialized {companion.Name}'s XP to {companion.Experience} for level {companion.Level}
                     }
 
@@ -1797,20 +1797,6 @@ namespace UsurperRemake.Systems
         #region Experience and Leveling
 
         /// <summary>
-        /// XP formula matching the player's curve (level^2.0 * 50)
-        /// </summary>
-        public static long GetExperienceForLevel(int level)
-        {
-            if (level <= 1) return 0;
-            long exp = 0;
-            for (int i = 2; i <= level; i++)
-            {
-                exp += (long)(Math.Pow(i, 2.0) * 50);
-            }
-            return exp;
-        }
-
-        /// <summary>
         /// Award experience to all active companions (typically 50% of what player earns)
         /// Companions auto-level when they hit the threshold
         /// </summary>
@@ -1840,7 +1826,7 @@ namespace UsurperRemake.Systems
                 // Show XP gain
                 if (terminal != null)
                 {
-                    long xpNeeded = GetExperienceForLevel(companion.Level + 1);
+                    long xpNeeded = GameConfig.GetExperienceForLevel(companion.Level + 1);
                     terminal.SetColor("bright_magenta");
                     terminal.WriteLine($"  {companion.Name}: {companion.Experience:N0}/{xpNeeded:N0}");
                 }
@@ -1869,7 +1855,7 @@ namespace UsurperRemake.Systems
         {
             if (companion.Level >= 100) return;
 
-            long xpForNextLevel = GetExperienceForLevel(companion.Level + 1);
+            long xpForNextLevel = GameConfig.GetExperienceForLevel(companion.Level + 1);
 
             while (companion.Experience >= xpForNextLevel && companion.Level < 100)
             {
@@ -1931,7 +1917,7 @@ namespace UsurperRemake.Systems
                 ModifyLoyalty(companion.Id, 1, "Leveled up through shared combat");
 
                 // Calculate next threshold
-                xpForNextLevel = GetExperienceForLevel(companion.Level + 1);
+                xpForNextLevel = GameConfig.GetExperienceForLevel(companion.Level + 1);
             }
         }
 
@@ -2090,7 +2076,7 @@ namespace UsurperRemake.Systems
         {
             // Start at RecruitLevel + 5 (as before, but now tracked)
             companion.Level = Math.Max(1, companion.RecruitLevel + 5);
-            companion.Experience = GetExperienceForLevel(companion.Level);
+            companion.Experience = GameConfig.GetExperienceForLevel(companion.Level);
 
             // Scale base stats to match level
             ScaleCompanionStatsToLevel(companion);

--- a/Scripts/Systems/NPCSpawnSystem.cs
+++ b/Scripts/Systems/NPCSpawnSystem.cs
@@ -403,7 +403,7 @@ namespace UsurperRemake.Systems
             npc.MaxHP = npc.HP;
             npc.MaxMana = npc.Mana;
             // Use same XP curve as players: level^2.0 * 50 per level
-            npc.Experience = GetExperienceForLevel(level);
+            npc.Experience = GameConfig.GetExperienceForLevel(level);
             npc.Gold = random.Next(level * 100, level * 500);
 
             // Add Constitution stat (was missing)
@@ -1111,21 +1111,6 @@ namespace UsurperRemake.Systems
                 _listVersion++;
         }
 
-        /// <summary>
-        /// Calculate experience points needed for a given level using same curve as players
-        /// Formula: Sum of level^2.0 * 50 for each level from 2 to target
-        /// </summary>
-        private static long GetExperienceForLevel(int level)
-        {
-            if (level <= 1) return 0;
-            long exp = 0;
-            for (int i = 2; i <= level; i++)
-            {
-                exp += (long)(Math.Pow(i, 2.0) * 50);
-            }
-            return exp;
-        }
-
         // Fantasy name pools for immigrant NPCs (shared with FamilySystem)
         private static readonly string[] ImmigrantMaleNames = new[]
         {
@@ -1221,7 +1206,7 @@ namespace UsurperRemake.Systems
                     Race = race,
                     Class = npcClass,
                     Level = level,
-                    Experience = GetExperienceForLevel(level),
+                    Experience = GameConfig.GetExperienceForLevel(level),
                     Strength = baseStat + random.Next(5),
                     Defence = baseStat + random.Next(5),
                     Stamina = baseStat + random.Next(5),

--- a/Scripts/Systems/WorldInitializerSystem.cs
+++ b/Scripts/Systems/WorldInitializerSystem.cs
@@ -486,7 +486,7 @@ public class WorldInitializerSystem
 
     private void CheckNPCLevelUp(NPC npc, int day)
     {
-        long expForNextLevel = GetExperienceForLevel(npc.Level + 1);
+        long expForNextLevel = GameConfig.GetExperienceForLevel(npc.Level + 1);
         if (npc.Experience >= expForNextLevel && npc.Level < 100)
         {
             npc.Level++;
@@ -646,20 +646,6 @@ public class WorldInitializerSystem
         } while (ActiveTeams.Any(t => t.Name == name) && attempts < 20);
 
         return name;
-    }
-
-    /// <summary>
-    /// Calculate XP needed for a level (matches other formulas)
-    /// </summary>
-    private static long GetExperienceForLevel(int level)
-    {
-        if (level <= 1) return 0;
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            exp += (long)(Math.Pow(i, 2.0) * 50);
-        }
-        return exp;
     }
 
     /// <summary>

--- a/Scripts/Systems/WorldSimService.cs
+++ b/Scripts/Systems/WorldSimService.cs
@@ -1619,7 +1619,7 @@ namespace UsurperRemake.Systems
 
                 // Fix XP for legacy data — also catches NPCs whose Experience was set from
                 // template.StartLevel instead of their actual Level (bug in GenerateNPCStats)
-                long expectedMinXP = GetExperienceForLevel(npc.Level);
+                long expectedMinXP = GameConfig.GetExperienceForLevel(npc.Level);
                 if (npc.Experience < expectedMinXP && npc.Level > 1)
                 {
                     npc.Experience = expectedMinXP;
@@ -1907,21 +1907,6 @@ namespace UsurperRemake.Systems
             {
                 DebugLogger.Instance.LogError("WORLDSIM", $"ProcessWorldDailyReset error: {ex.Message}");
             }
-        }
-
-        /// <summary>
-        /// Calculate experience needed for a given level.
-        /// Same formula as WorldSimulator.GetExperienceForLevel.
-        /// </summary>
-        private static long GetExperienceForLevel(int level)
-        {
-            if (level <= 1) return 0;
-            long exp = 0;
-            for (int i = 2; i <= level; i++)
-            {
-                exp += (long)(Math.Pow(i, 2.0) * 50);
-            }
-            return exp;
         }
     }
 }

--- a/Scripts/Systems/WorldSimulator.cs
+++ b/Scripts/Systems/WorldSimulator.cs
@@ -1782,7 +1782,7 @@ public class WorldSimulator
         }
 
         // Visit level master if eligible
-        long expForNextLevel = GetExperienceForLevel(npc.Level + 1);
+        long expForNextLevel = GameConfig.GetExperienceForLevel(npc.Level + 1);
         if (npc.Experience >= expForNextLevel && npc.Level < 100)
         {
             activities.Add(("levelup", 0.30));
@@ -3205,7 +3205,7 @@ public class WorldSimulator
     private void NPCVisitMaster(NPC npc)
     {
         npc.UpdateLocation("Level Master");
-        long expNeeded = GetExperienceForLevel(npc.Level + 1);
+        long expNeeded = GameConfig.GetExperienceForLevel(npc.Level + 1);
         if (npc.Experience >= expNeeded && npc.Level < 100)
         {
             npc.Level++;
@@ -3260,20 +3260,6 @@ public class WorldSimulator
         }
     }
 
-    /// <summary>
-    /// Calculate XP needed for a level (matches player formula)
-    /// </summary>
-    private static long GetExperienceForLevel(int level)
-    {
-        if (level <= 1) return 0;
-        long exp = 0;
-        for (int i = 2; i <= level; i++)
-        {
-            exp += (long)(Math.Pow(i, 2.0) * 50);
-        }
-        return exp;
-    }
-    
     private void ExecuteNPCAction(NPC npc, NPCAction action, WorldState world)
     {
         switch (action.Type)


### PR DESCRIPTION
# Fix XP threshold desync — canonicalize `GetExperienceForLevel` in `GameConfig`

## Bug report

> **Version:** 0.60.4  
> **Platform:** Linux X64  
> **Build:** Online  
> **Player:** Coosh — Lv.73 Troll Warrior  
> **Location:** MainStreet
>
> I didn't get my lvl up automatically, went over the XP required for the level
> (now xp to level shows negative value). the trainer says not available too.

## Root cause

When the late-game XP curve was steepened (levels 51+ use exponent `2.25`
instead of `2.0`), only `LevelMasterLocation.GetExperienceForLevel` was updated. There
were 12 copies of this function spread across the codebase and 11 of them were left
behind still using the flat `2.0` exponent.

This caused a visible desync: the Trainer (correct formula) showed you needed ~8.6M XP
to reach level 74, while the Status window, Dungeon, and every NPC/companion system
(stale formula) computed the threshold as ~6.9M — causing the XP bar to display
negative progress for high-level characters, and the auto-level-up check to never fire.

`GameConfig.GetSessionXPThreshold` had the same inline exponent assumption and was also stale.

## Fix

Added `GameConfig.GetExperienceForLevel(int level)` as the single canonical implementation
with the correct dual-exponent curve, then replaced all 11 stale copies across the codebase.

`LevelMasterLocation.GetExperienceForLevel` is kept as a public pass-through to preserve
the existing external call API.

## Files changed

| File | Change |
|---|---|
| `GameConfig.cs` | Added canonical `GetExperienceForLevel`; fixed `GetSessionXPThreshold` exponent |
| `LevelMasterLocation.cs` | Replaced 18-line loop with `return GameConfig.GetExperienceForLevel(level)` |
| `BaseLocation.cs` | Removed stale private copy; 7 call sites updated |
| `CombatEngine.cs` | Removed stale private copy; 6 call sites updated |
| `CompanionSystem.cs` | Removed stale private copy; 6 call sites updated |
| `MainStreetLocation.cs` | Removed stale private copy; 3 call sites updated |
| `DungeonLocation.cs` | Removed stale private copy; 2 call sites updated |
| `NPCSpawnSystem.cs` | Removed stale private copy; 2 call sites updated |
| `WorldSimulator.cs` | Removed stale private copy; 2 call sites updated |
| `NPC.cs` | Removed stale private copy; 1 call site updated |
| `WorldInitializerSystem.cs` | Removed stale private copy; 1 call site updated |
| `WorldSimService.cs` | Removed stale private copy; 1 call site updated |
| `GameEngine.cs` | Removed stale `GetExperienceForNPCLevel`; 1 call site updated |

32 call sites redirected to `GameConfig.GetExperienceForLevel`. Build passes with 0 errors.

## Question for @binary-knight 

I placed the canonical method in `GameConfig` since `GetSessionXPThreshold` already
lives there, but I'm not fully convinced it's the right home. `GameConfig` tends to
hold constants and settings this is a computational formula with a loop. A dedicated
`Progression.cs` class might be cleaner long-term, especially if more XP curve methods
accumulate here. Happy to move it if you have a preference.