### PR TITLE
Emit GMCP Char.Status when gold, bank, XP, or level changes

### DIFF
--- a/Scripts/Locations/BaseLocation.cs
+++ b/Scripts/Locations/BaseLocation.cs
@@ -74,6 +74,15 @@ public abstract class BaseLocation
         => UsurperRemake.Server.GmcpBridge.EmitVitalsIfChanged(player);
 
     /// <summary>
+    /// Emit GMCP Char.Status if gold, bank, XP or level changed since last emit.
+    /// Mirrors the EmitGmcpVitals pattern — called on every loop iteration so any
+    /// in-location transaction (shop purchase, bank deposit, quest reward, etc.)
+    /// is reflected in the MUD client's status display within one loop tick.
+    /// </summary>
+    private void EmitGmcpStatus(Character player)
+        => UsurperRemake.Server.GmcpBridge.EmitStatusIfChanged(player);
+
+    /// <summary>
     /// True when this session should use compact BBS menus (80x24 terminal).
     /// Covers both single-player BBS door mode and MUD server BBS connections.
     /// </summary>
@@ -566,6 +575,10 @@ public abstract class BaseLocation
             // boolean check + early return for non-GMCP clients (web, SSH, BBS).
             // Mudlet/MUSHclient/TT++ users get live HP/MP/SP gauges via this stream.
             EmitGmcpVitals(currentPlayer);
+            // Re-emit Char.Status whenever gold/bank/XP/level changed since the last
+            // send. Covers every in-location transaction without touching the ~180
+            // individual mutation sites scattered across location files.
+            EmitGmcpStatus(currentPlayer);
 
             // Nightmare permadeath — save deleted, exit immediately
             if (GameEngine.Instance.IsPermadeath)

--- a/Scripts/Server/GmcpBridge.cs
+++ b/Scripts/Server/GmcpBridge.cs
@@ -104,6 +104,46 @@ public static class GmcpBridge
     }
 
     /// <summary>
+    /// Emit Char.Status if gold, bank balance, XP, or level changed since the last
+    /// emit on this session. Called on every location-loop iteration and at combat
+    /// end so MUD clients always see up-to-date wealth and progression without
+    /// waiting for the next location transition. Cheap no-op when GMCP isn't
+    /// negotiated.
+    /// </summary>
+    public static void EmitStatusIfChanged(global::Character? player)
+    {
+        if (player == null || !IsActive) return;
+        var ctx = SessionContext.Current;
+        if (ctx == null) return;
+
+        long gold = player.Gold;
+        long bank = player.BankGold;
+        long xp   = player.Experience;
+        int  level = player.Level;
+
+        if (gold == ctx.LastGmcpGold && bank == ctx.LastGmcpBankGold
+            && xp == ctx.LastGmcpXp && level == ctx.LastGmcpLevel)
+            return;
+
+        ctx.LastGmcpGold    = gold;
+        ctx.LastGmcpBankGold = bank;
+        ctx.LastGmcpXp      = xp;
+        ctx.LastGmcpLevel   = level;
+
+        Emit("Char.Status", new
+        {
+            name     = player.Name2 ?? player.Name1,
+            @class   = player.Class.ToString(),
+            level,
+            race     = player.Race.ToString(),
+            gold,
+            bank,
+            xp,
+            location = player.CurrentLocation
+        });
+    }
+
+    /// <summary>
     /// v0.60.3: emit Char.Items.List with the full backpack contents and equipped
     /// items. Called at character login and on combat end (post-loot pickup).
     /// MUD client scripts can wire this to inventory panes / equipment displays

--- a/Scripts/Server/SessionContext.cs
+++ b/Scripts/Server/SessionContext.cs
@@ -60,6 +60,14 @@ public class SessionContext : IDisposable
     public long LastGmcpMaxMana { get; set; } = -1;
     public long LastGmcpStamina { get; set; } = -1;
 
+    // Per-session delta tracking for GMCP Char.Status (gold / bank / xp / level).
+    // Initialised to sentinel values so the first emit always fires regardless of
+    // whether the player started with 0 gold or level 1.
+    public long LastGmcpGold { get; set; } = long.MinValue;
+    public long LastGmcpBankGold { get; set; } = long.MinValue;
+    public long LastGmcpXp { get; set; } = long.MinValue;
+    public int LastGmcpLevel { get; set; } = -1;
+
     /// <summary>
     /// v0.60.3: consecutive emit failure counter. Reset to 0 on every successful
     /// emit; after GmcpBridge.MaxConsecutiveErrors failures in a row the bridge

--- a/Scripts/Systems/CombatEngine.cs
+++ b/Scripts/Systems/CombatEngine.cs
@@ -1607,6 +1607,10 @@ public partial class CombatEngine
             UsurperRemake.Server.GmcpBridge.EmitItemsList(player);
             UsurperRemake.Server.GmcpBridge.EmitSkillsList(player);
             UsurperRemake.Server.GmcpBridge.EmitVitalsIfChanged(player);
+            // Gold and XP always change after combat — push Char.Status so the
+            // client's wealth and progression display updates without waiting for
+            // the next location transition.
+            UsurperRemake.Server.GmcpBridge.EmitStatusIfChanged(player);
         }
 
         return result;

--- a/Scripts/Systems/LocationManager.cs
+++ b/Scripts/Systems/LocationManager.cs
@@ -372,6 +372,15 @@ public class LocationManager
                 xp = player.Experience,
                 location = currentLocation?.LocationName ?? locationId.ToString()
             });
+            // Sync delta-tracking so the first loop iteration doesn't immediately
+            // re-emit the same values we just sent unconditionally on location entry.
+            if (gmcpCtx != null)
+            {
+                gmcpCtx.LastGmcpGold     = player.Gold;
+                gmcpCtx.LastGmcpBankGold = player.BankGold;
+                gmcpCtx.LastGmcpXp       = player.Experience;
+                gmcpCtx.LastGmcpLevel    = player.Level;
+            }
         }
 
         // Advance game time for travel between locations (single-player only)


### PR DESCRIPTION
## Fix: Re-emit `Char.Status` after gold/XP changes

### Bug report

**Version:** 0.60.5  
**Platform:** Linux X64  
**Build:** Online  
**Player:** Coosh — Lv.73 Troll Warrior  
**Location:** Bank  

> The `Char.Status.gold` GMCP message isn't being updated properly.

---

### Root cause

`Char.Status` (which carries `gold`, `bank`, `xp`, and `level`) was only ever
emitted in one place: `LocationManager.EnterLocation`. Any change to those
values that happened *within* a location was invisible to the MUD client until
the player physically moved somewhere else.

In the Bank specifically: depositing or withdrawing gold updated the in-memory
`Character` object immediately, but `Char.Status` wasn't re-sent until the
player left and entered a new location. The client's gold display was therefore
always one location transition behind reality.

The same stale-until-move behaviour affected every other gold-changing mechanic
in the game — shops, combat loot, gambling, quest rewards, death penalties, etc.

---

### Solution

Adopted the same delta-tracking pattern already used by `EmitVitalsIfChanged`
for HP/MP/SP.

**`SessionContext.cs`** — four new per-session sentinel fields alongside the
existing vitals trackers. Initialized to sentinel values so the first emit
always fires regardless of starting gold or level.

**`GmcpBridge.cs`** — new `EmitStatusIfChanged(Character player)` method that
compares current gold/bank/XP/level against last-emitted values, no-ops if
nothing changed, and emits `Char.Status` when any value differs. Single
`IsActive` check means it's free for non-GMCP clients.

**`BaseLocation.cs`** — new `EmitGmcpStatus(player)` private wrapper called in
`LocationLoop` immediately after the existing `EmitGmcpVitals` call. This covers
all ~180 gold mutation sites across every location file without touching any of
them individually — every shop purchase, bank transaction, quest reward,
gambling result, etc. is picked up on the next loop tick.

**`LocationManager.cs`** — after the unconditional `Char.Status` emit on
location entry, the four new tracking fields are synced to the just-sent values.
Without this the first loop iteration in the new location would see stale
sentinels and send a redundant duplicate of the entry emit.

**`CombatEngine.cs`** — `EmitStatusIfChanged(player)` added to the
`Char.Combat.End` block alongside the existing `EmitVitalsIfChanged` call.
Combat is the one gold/XP-change path that runs entirely outside the location
loop, so it required its own explicit call.

---

### Why not patch every mutation site directly?

There are roughly 180 `player.Gold` / `player.BankGold` mutation sites spread
across 30+ files. Patching each one individually would be noisy, error-prone,
and would silently regress every time a new gold-changing mechanic is added. The
loop-based delta approach is self-healing — any future mutation inside a
location is automatically covered with no extra work.

---

### Files changed

| File | Change |
|---|---|
| `Scripts/Server/SessionContext.cs` | Add 4 `LastGmcp*` delta-tracking fields |
| `Scripts/Server/GmcpBridge.cs` | Add `EmitStatusIfChanged` |
| `Scripts/Locations/BaseLocation.cs` | Add `EmitGmcpStatus` wrapper + call in loop |
| `Scripts/Systems/LocationManager.cs` | Sync tracking state after unconditional entry emit |
| `Scripts/Systems/CombatEngine.cs` | Call `EmitStatusIfChanged` at `Char.Combat.End` |
