### PR TITLE
Emit live enemy HP updates via GMCP each combat round

### DIFF
--- a/Scripts/Systems/CombatEngine.cs
+++ b/Scripts/Systems/CombatEngine.cs
@@ -1377,6 +1377,28 @@ public partial class CombatEngine
             // the menu redraws. Cheap no-op when GMCP isn't negotiated.
             UsurperRemake.Server.GmcpBridge.EmitVitalsIfChanged(player);
 
+            // Emit Char.Combat.Enemies each round so MUD clients see live enemy HP
+            // values as they change. Char.Combat.Start emits the initial snapshot;
+            // without this, enemy gauges stay frozen at their starting HP until the
+            // fight ends. Cheap no-op when GMCP isn't negotiated.
+            if (UsurperRemake.Server.GmcpBridge.IsActive)
+            {
+                var enemyUpdate = monsters.Select(m => new
+                {
+                    name   = m.Name,
+                    level  = m.Level,
+                    hp     = m.HP,
+                    maxHp  = m.MaxHP,
+                    isBoss = m.IsBoss || m.IsMiniBoss,
+                    alive  = m.IsAlive
+                }).ToList();
+                UsurperRemake.Server.GmcpBridge.Emit("Char.Combat.Enemies", new
+                {
+                    enemies = enemyUpdate,
+                    round   = result.CurrentRound
+                });
+            }
+
             // Short pause between rounds
             await Task.Delay(GetCombatDelay(1000));
         }


### PR DESCRIPTION
## Fix: emit `Char.Combat.Enemies` GMCP frame each combat round

### Problem

`Char.Combat.Start` sends an initial enemy snapshot (name, level, hp, maxHp, isBoss)
when combat begins, but no subsequent GMCP frames were sent to update enemy health
as the fight progressed. The only per-round GMCP call was `EmitVitalsIfChanged(player)`,
which tracks the player's HP/MP/SP only. MUD clients displaying enemy health gauges
(Mudlet, MUSHclient, TinTin++, etc.) would see enemies frozen at their starting HP
for the entire fight, with values only resolving correctly after `Char.Combat.End`.

### Fix

Added a `Char.Combat.Enemies` emit at the end of every round in `PlayerVsMonsters`,
immediately after the existing `EmitVitalsIfChanged` call.

The frame carries the full enemy object shape — matching `Char.Combat.Start` exactly —
plus an `alive` field and a `round` sequence number:

```json
{
  "enemies": [
    { "name": "Orc", "level": 5, "hp": 42, "maxHp": 120, "isBoss": false, "alive": true },
    { "name": "Troll", "level": 8, "hp": 0, "maxHp": 300, "isBoss": false, "alive": false }
  ],
  "round": 3
}
```

### Notes

- `PlayerVsMonster` (single-enemy) already delegates to `PlayerVsMonsters`, so both
  paths are covered by this single change.
- The shape is a strict superset of the `Char.Combat.Start` enemy object, so existing
  client scripts can reuse the same model without any changes.
- The `alive` flag lets clients grey out or remove dead enemies from their display
  without waiting for `Char.Combat.Killed`.
- The emit is gated on `GmcpBridge.IsActive` — no-op for non-GMCP sessions.
