### PR TITLE
Add GMCP Combat.Party emit for live party status updates

### DIFF
--- a/Scripts/Server/GmcpBridge.cs
+++ b/Scripts/Server/GmcpBridge.cs
@@ -245,6 +245,58 @@ public static class GmcpBridge
     }
 
     /// <summary>
+    /// Build and emit a Combat.Party frame for the given party list. Does not check
+    /// for changes; callers should use EmitCombatPartyIfChanged for per-round calls.
+    /// </summary>
+    private static void EmitCombatPartyInternal(System.Collections.Generic.List<global::Character> party)
+    {
+        var members = party.Select(m => new
+        {
+            name     = m.DisplayName,
+            @class   = m.Class.ToString(),
+            level    = m.Level,
+            hp       = m.HP,
+            maxHp    = m.MaxHP,
+            mp       = m.Mana,
+            maxMp    = m.MaxMana,
+            isAlive  = m.IsAlive,
+            isPlayer = m.IsGroupedPlayer,
+            isCompanion = m.IsCompanion,
+            statuses = m.ActiveStatuses.Keys
+                         .Select(s => s.ToString().ToLower())
+                         .ToList()
+        }).ToList();
+
+        Emit("Combat.Party", new { members, count = members.Count });
+    }
+
+    /// <summary>
+    /// Emit Combat.Party if any tracked party member stat changed since the last
+    /// emit on this session. Called at the end of each combat round (alongside
+    /// EmitVitalsIfChanged) so MUD clients see live party HP/MP/status throughout
+    /// the fight. Also used at Combat.Start to seed the initial party state.
+    /// Cheap no-op when GMCP isn't negotiated or the party list is empty.
+    /// </summary>
+    public static void EmitCombatPartyIfChanged(System.Collections.Generic.List<global::Character>? party)
+    {
+        if (party == null || party.Count == 0 || !IsActive) return;
+        var ctx = SessionContext.Current;
+        if (ctx == null) return;
+
+        // Build a compact snapshot string for change detection.
+        // Format: "name|hp|maxHp|mana|maxMana|alive;" per member.
+        var sb = new System.Text.StringBuilder();
+        foreach (var m in party)
+            sb.Append($"{m.DisplayName}|{m.HP}|{m.MaxHP}|{m.Mana}|{m.MaxMana}|{m.IsAlive};");
+        var snapshot = sb.ToString();
+
+        if (snapshot == ctx.LastGmcpPartySnapshot) return;
+        ctx.LastGmcpPartySnapshot = snapshot;
+
+        EmitCombatPartyInternal(party);
+    }
+
+    /// <summary>
     /// Emit a GMCP frame to the current session's output stream.
     /// Package format follows the GMCP convention: "Module.Submodule" (e.g. "Char.Vitals",
     /// "Room.Info", "Comm.Channel.Text"). Payload is JSON-serialized with camelCase property

--- a/Scripts/Server/SessionContext.cs
+++ b/Scripts/Server/SessionContext.cs
@@ -68,6 +68,10 @@ public class SessionContext : IDisposable
     public long LastGmcpXp { get; set; } = long.MinValue;
     public int LastGmcpLevel { get; set; } = -1;
 
+    // Per-session delta tracking for GMCP Combat.Party
+    // Snapshot string lets us skip redundant emits when party HP hasn't changed.
+    public string LastGmcpPartySnapshot { get; set; } = "";
+
     /// <summary>
     /// v0.60.3: consecutive emit failure counter. Reset to 0 on every successful
     /// emit; after GmcpBridge.MaxConsecutiveErrors failures in a row the bridge

--- a/Scripts/Systems/CombatEngine.cs
+++ b/Scripts/Systems/CombatEngine.cs
@@ -466,6 +466,9 @@ public partial class CombatEngine
                 enemies = enemyData,
                 ambush = isAmbush
             });
+            // Seed initial party state so MUD clients can render party panes
+            // without waiting for the first round-end update.
+            UsurperRemake.Server.GmcpBridge.EmitCombatPartyIfChanged(teammates);
         }
 
         // Store teammates for healing/support actions
@@ -1376,6 +1379,8 @@ public partial class CombatEngine
             // HP/MP/SP throughout the fight instead of frozen pre-combat values until
             // the menu redraws. Cheap no-op when GMCP isn't negotiated.
             UsurperRemake.Server.GmcpBridge.EmitVitalsIfChanged(player);
+            // Emit Combat.Party update if any party member HP/status changed this round.
+            UsurperRemake.Server.GmcpBridge.EmitCombatPartyIfChanged(result.Teammates);
 
             // Short pause between rounds
             await Task.Delay(GetCombatDelay(1000));
@@ -1607,6 +1612,8 @@ public partial class CombatEngine
             UsurperRemake.Server.GmcpBridge.EmitItemsList(player);
             UsurperRemake.Server.GmcpBridge.EmitSkillsList(player);
             UsurperRemake.Server.GmcpBridge.EmitVitalsIfChanged(player);
+            // Final party state at combat end (captures deaths, full heals on victory, etc.)
+            UsurperRemake.Server.GmcpBridge.EmitCombatPartyIfChanged(result.Teammates);
             // Gold and XP always change after combat — push Char.Status so the
             // client's wealth and progression display updates without waiting for
             // the next location transition.
@@ -1729,6 +1736,8 @@ public partial class CombatEngine
             // Covers single-monster combat (which doesn't go through the multi-monster
             // end-of-round path above). Cheap no-op when GMCP isn't negotiated.
             UsurperRemake.Server.GmcpBridge.EmitVitalsIfChanged(player);
+            // Emit Combat.Party if party member HP/status changed since last prompt.
+            UsurperRemake.Server.GmcpBridge.EmitCombatPartyIfChanged(result.Teammates);
 
             // Check if player can act due to status effects
             if (!player.CanAct())


### PR DESCRIPTION
# Add `Combat.Party` GMCP Event

## Summary

Adds a `Combat.Party` GMCP event so MUD clients can track party member health and status throughout a fight. The existing `Char.Combat.Start` already emits the enemy list; party members had no equivalent. Mudlet scripts and other GMCP-aware clients currently have no way to render party HP bars or detect when a teammate dies without text-pattern matching the combat output.

## What Changed

- **`Combat.Party`** is emitted at the start of every fight (alongside the existing enemy list in `Char.Combat.Start`) and again at the end of each round whenever any member's HP, mana, or alive status changes. Also fires at the player-turn prompt (covers single-monster fights that don't go through the multi-round path) and one final time at `Char.Combat.End` to capture deaths and post-victory heals.
- Emission is change-detected — identical party state between rounds is skipped. Cheap no-op for solo players with no party members.
- Payload per member: `name`, `class`, `level`, `hp`, `maxHp`, `mp`, `maxMp`, `isAlive`, `isPlayer` (grouped echo), `isCompanion`, `statuses` (list of active status effect names).

Example frame:
```json
{
  "count": 2,
  "members": [
    {
      "name": "Zareth",
      "class": "Warrior",
      "level": 15,
      "hp": 420, "maxHp": 500,
      "mp": 0, "maxMp": 0,
      "isAlive": true,
      "isPlayer": false,
      "isCompanion": true,
      "statuses": ["poisoned"]
    }
  ]
}
```

## Files Changed

| File | Change |
|---|---|
| `Scripts/Server/GmcpBridge.cs` | Added `EmitCombatPartyIfChanged(List<Character>?)` (public, change-detected) and `EmitCombatPartyInternal` (private, unconditional emit) |
| `Scripts/Server/SessionContext.cs` | Added `LastGmcpPartySnapshot` for per-session delta tracking |
| `Scripts/Systems/CombatEngine.cs` | Wired `EmitCombatPartyIfChanged` at four points: `Char.Combat.Start`, end-of-round, player-turn prompt, and `Char.Combat.End` |
