### PR TITLE
Fix typo in level_master.menu_path

### DIFF
--- a/Localization/en.json
+++ b/Localization/en.json
@@ -1803,7 +1803,7 @@
   "level_master.level_raise": "Level Raise",
   "level_master.abilities": "Abilities",
   "level_master.abilities_desc": "view and learn combat abilities or spells",
-  "level_master.menu_path": "Path - {0}",
+  "level_master.menu_path": "ath - {0}",
   "level_master.menu_specialize": "Specialize - {0}",
   "level_master.specialize_desc": "choose your class specialization (level 25+)",
   "level_master.path_desc": "see your next abilities, spells, and story milestone",


### PR DESCRIPTION
Corrected a basic typo in the English Level Master menu path string.

Resolves this double P in the Level Master Menu: 
<img width="700" height="430" alt="Screenshot 2026-07-21 at 8 29 13 PM" src="https://github.com/user-attachments/assets/3d39eb85-6414-4100-bfdb-cfdb43a85d8a" />

