### PR TITLE
v1.0.6: fix input stomping on every connection type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ nul
 tools/
 DOCS/FEEDBACK_PLAN_0.56.0.md
 AGENTS.md
+__pycache__/

--- a/DOCS/ARCHITECTURE.md
+++ b/DOCS/ARCHITECTURE.md
@@ -1370,7 +1370,7 @@ Output modes (auto-detected):
 
 **Spectator forwarding**: `_spectatorStreams` set; output methods call `ForwardToSpectators(text)`. Markup is rendered to a string before duplication.
 
-**ServerEchoes flag**: controls server-side echo for ReadLineInteractiveAsync. True only for direct raw TCP MUD clients (Mudlet, TinTin++, VIP Mud); false for all relay connections (Web, SSH) where the PTY handles echo.
+**ServerEchoes flag**: controls whether the server owns the input line in ReadLineInteractiveAsync (echoes keystrokes, and erases-and-redraws the line when a message lands mid-typing). v1.0.6: true for direct raw TCP MUD clients (Mudlet, TinTin++, VIP Mud), the web terminal (`X-Client:Web`; xterm.js streams keystrokes and never echoes locally), and the SSH relay when it has put its PTY in raw mode (AUTH type `SSH;echo=1`, see `TerminalRawMode`). False for the desktop/Steam, BBS door, and Electron clients, which keep their own line editor; for those the server never erases the line and delivers messages on a fresh line followed by the redrawn prompt. The prompt redrawn is the tracked output line (`OutputLineTracker`), not GetInput's prompt argument. Reproduction harness: `Tests/Harness/input-stomping/`.
 
 ### UIHelper
 **File**: `Scripts/UI/UIHelper.cs`

--- a/DOCS/RELEASE_NOTES_1.0.6.md
+++ b/DOCS/RELEASE_NOTES_1.0.6.md
@@ -59,10 +59,14 @@ Found while making the SyncTerm harness case pass. The telnet probe that asks a
 client for its terminal type gives it 250 ms to answer. When that window closed,
 the cancellation escaped past the block that reads the answer, so a reply that
 had already arrived was discarded. CP437 terminals (SyncTerm, NetRunner,
-mTelnet, fTelnet) were therefore being sent UTF-8 box glyphs, and GMCP was never
-negotiated for MUD clients that offered it. Both now take effect. This is the
-likely cause of the garbled-box-art reports from BBS terminals (issue #102 is the
-open one; please retest).
+mTelnet, fTelnet) were therefore being sent UTF-8 box glyphs, and screen-reader
+clients that identify as VIP, DUMB, or UNKNOWN never got plain-text mode. This
+has been the case since v0.47.1. GMCP and echo negotiation were not affected.
+Both detections now take effect for the first time, so watch the
+`[MUD] TTYPE detected:` server log line on deploy day for client strings that
+should not be treated as plain text. This is the likely cause of issue #102
+(garbled box art on a Mystic BBS terminal); the reporter should retest on 1.0.6
+before it is closed.
 
 ## Not changed
 

--- a/DOCS/RELEASE_NOTES_1.0.6.md
+++ b/DOCS/RELEASE_NOTES_1.0.6.md
@@ -53,6 +53,17 @@ always wrong for them.
 - The web proxy now drops the browser's window-resize control message, which
   was being typed into the player's input buffer.
 
+## Terminal-type detection was being thrown away
+
+Found while making the SyncTerm harness case pass. The telnet probe that asks a
+client for its terminal type gives it 250 ms to answer. When that window closed,
+the cancellation escaped past the block that reads the answer, so a reply that
+had already arrived was discarded. CP437 terminals (SyncTerm, NetRunner,
+mTelnet, fTelnet) were therefore being sent UTF-8 box glyphs, and GMCP was never
+negotiated for MUD clients that offered it. Both now take effect. This is the
+likely cause of the garbled-box-art reports from BBS terminals (issue #102 is the
+open one; please retest).
+
 ## Not changed
 
 - The 500 ms typing grace stays; it only delays a message while a key was
@@ -73,12 +84,13 @@ tracking writer, AUTH parameter parsing).
 The reproduction harness is in `Tests/Harness/input-stomping` with a README.
 It runs a local server and scripted clients for the MUD, web, SyncTerm,
 desktop, and SSH-under-a-PTY cases, types mid-line, sends a tell from a second
-account, and prints the bytes the first player's screen received. Four of the
-five cases are green on this release: message on its own line, exact prompt
-restored, typed text present exactly once (zero on the desktop path, where the
-client re-shows its own buffer). The SyncTerm case runs but its scripted
-terminal-type reply does not trigger CP437 detection; the desktop case measures
-the server side only, and the client's re-echo was checked by hand.
+account, and prints the bytes the first player's screen received. All five
+cases are green on this release: message on its own line, exact prompt restored,
+typed text present exactly once (zero on the scripted desktop case, which
+measures the server side only). Two further cases were run by hand against a
+local sshd gateway container: an SSH terminal through the real ForceCommand
+relay, and the actual desktop binary through the SSH gateway, which re-showed
+its half-typed text once and submitted the full line on Enter.
 
 ## Files Changed
 

--- a/DOCS/RELEASE_NOTES_1.0.6.md
+++ b/DOCS/RELEASE_NOTES_1.0.6.md
@@ -1,0 +1,105 @@
+# Usurper Reborn v1.0.6
+
+One fix: a chat, tell, or world message arriving while you were typing no
+longer destroys what you typed. This has been reported since the online server
+opened and every earlier attempt fixed one connection type by breaking another.
+This time each connection type was measured with a scripted client before any
+code changed, and the reproduction harness ships with the game.
+
+## What was actually happening
+
+There was no single bug. Four connection paths failed in four different ways.
+
+**Web terminal.** The server only echoed keystrokes for MUD clients, and the
+browser terminal never echoes on its own. Web players have been typing blind
+in game since the site moved to the direct TCP proxy: the text you typed was
+invisible until a message happened to trigger a redraw, and every broadcast
+erased the prompt line and left an empty one. Verified in a browser against the
+real page. Login prompts did echo, which is why it was not obvious on first
+contact.
+
+**SSH.** The relay that sshd runs read its terminal through .NET's line-mode
+console reader, which holds each line locally, echoes it itself, and hands it
+over on Enter. The server never saw the text, so when it erased the line to
+print a message it wiped text the relay still held. Enter then submitted the
+invisible line and the player retyped, getting a doubled command.
+
+**MUD clients (Mudlet, TinTin++, telnet).** Echo and redraw worked, but the
+redraw printed the prompt argument the code had passed to the input call,
+usually nothing or "Your choice:", not the "[27hp 100st] Main Street >" line
+the game had written separately. After every message the visible prompt was
+wrong or gone.
+
+**Desktop, Steam, and BBS door clients.** These keep their own line editor and
+show the text themselves. The server cannot see it, so erasing the line was
+always wrong for them.
+
+## What changed
+
+- The terminal now remembers the text on the current output line (colours
+  kept, cursor movement dropped) and redraws exactly that after a message.
+- The server owns the input line, echoing keystrokes and redrawing after a
+  message, for MUD clients, the web terminal, and SSH. For SSH the relay puts
+  its terminal in raw mode (termios via P/Invoke; a spawned `stty` would be
+  undone by the .NET runtime), forwards keystrokes one at a time, and asks the
+  server to echo with `SSH;echo=1` in the existing AUTH connection-type field.
+  An older server ignores the suffix, so relay and server can be upgraded in
+  either order.
+- For clients that keep their own line, the server never erases it. It moves
+  to a fresh line, prints the messages, and redraws the prompt. The desktop
+  client re-shows its half-typed text once a prompt is back on screen.
+- Screen-reader sessions never receive erase sequences. CP437 clients get the
+  redraw through the same translation as everything else. Spectators see it.
+- The web proxy now drops the browser's window-resize control message, which
+  was being typed into the player's input buffer.
+
+## Not changed
+
+- The 500 ms typing grace stays; it only delays a message while a key was
+  just pressed.
+- Only one row is erased on redraw. The server does not know the terminal
+  width, so a wrapped input line still leaves its earlier rows behind.
+- BBS door players see their partial text again only after pressing Enter.
+- Electron online play is unchanged. It streams keystrokes without local echo
+  on the raw path and may have the same blind-typing problem the web had.
+- Web spectators now see their own keystroke echo inside the mirrored stream,
+  as MUD spectators already did.
+
+## Tests
+
+977 passing, up from 958. New: `OutputLineTrackerTests` (line tracker, the
+tracking writer, AUTH parameter parsing).
+
+The reproduction harness is in `Tests/Harness/input-stomping` with a README.
+It runs a local server and scripted clients for the MUD, web, SyncTerm,
+desktop, and SSH-under-a-PTY cases, types mid-line, sends a tell from a second
+account, and prints the bytes the first player's screen received. Four of the
+five cases are green on this release: message on its own line, exact prompt
+restored, typed text present exactly once (zero on the desktop path, where the
+client re-shows its own buffer). The SyncTerm case runs but its scripted
+terminal-type reply does not trigger CP437 detection; the desktop case measures
+the server side only, and the client's re-echo was checked by hand.
+
+## Files Changed
+
+**New**
+
+- `DOCS/RELEASE_NOTES_1.0.6.md`
+- `DOCS/STEAM_RELEASE_NOTES_1.0.6.txt`
+- `Scripts/Server/TerminalRawMode.cs`
+- `Scripts/UI/OutputLineTracker.cs`
+- `Tests/Harness/input-stomping/` (README, five scripts)
+- `Tests/OutputLineTrackerTests.cs`
+
+**Modified**
+
+- `.gitignore`
+- `DOCS/ARCHITECTURE.md`
+- `README.md`
+- `Scripts/Core/GameConfig.cs`
+- `Scripts/Server/MudServer.cs`
+- `Scripts/Server/PlayerSession.cs`
+- `Scripts/Server/RelayClient.cs`
+- `Scripts/Systems/OnlinePlaySystem.cs`
+- `Scripts/UI/TerminalEmulator.cs`
+- `web/ssh-proxy.js`

--- a/DOCS/STEAM_RELEASE_NOTES_1.0.6.txt
+++ b/DOCS/STEAM_RELEASE_NOTES_1.0.6.txt
@@ -12,6 +12,7 @@ This time I stopped guessing. I built a test rig that connects to the server eve
 [*][b]Mudlet, TinTin++, telnet:[/b] after a message the real prompt comes back, not a blank line or "Your choice:".
 [*][b]Steam and desktop client:[/b] a message goes on its own line and your half-typed text is shown again underneath the prompt.
 [*][b]Screen readers:[/b] no more erase codes in the stream.
+[*][b]SyncTerm, NetRunner and other BBS terminals:[/b] the server was throwing away your terminal type, so you were getting the wrong box-drawing characters. Fixed while testing this release. If your box art was garbage before, try again.
 [/list]
 
 [h2]Still on the list[/h2]

--- a/DOCS/STEAM_RELEASE_NOTES_1.0.6.txt
+++ b/DOCS/STEAM_RELEASE_NOTES_1.0.6.txt
@@ -1,0 +1,21 @@
+[h1]Usurper Reborn 1.0.6 - Typing Fix[/h1]
+
+One fix, and it is the one I have been chasing since the online server opened. When a chat message, a tell, or a world event landed while you were in the middle of typing, it would wipe out what you had typed. Every time I fixed it for one way of connecting it broke for another.
+
+This time I stopped guessing. I built a test rig that connects to the server every way the game supports, types half a line, sends a message from a second account, and records exactly what shows up on the screen. It turned out there were four different problems, one per kind of connection.
+
+[h2]What you will notice[/h2]
+
+[list]
+[*][b]Browser players:[/b] you can now see what you type in game. You could not before. That was not a display glitch on your end, the server simply never sent your keystrokes back.
+[*][b]SSH players:[/b] a message arriving mid-line no longer erases your text and then submits it invisibly.
+[*][b]Mudlet, TinTin++, telnet:[/b] after a message the real prompt comes back, not a blank line or "Your choice:".
+[*][b]Steam and desktop client:[/b] a message goes on its own line and your half-typed text is shown again underneath the prompt.
+[*][b]Screen readers:[/b] no more erase codes in the stream.
+[/list]
+
+[h2]Still on the list[/h2]
+
+If your typed line is long enough to wrap, the earlier rows are not cleared when a message lands. BBS door players see their partial text again only after pressing Enter. If you play through a BBS or a client I have not named here and something still looks off, use /bug in game and tell me which program you use.
+
+The test rig ships with the game, so this stays fixed.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## A Persistent Online Text RPG with a Living World
 
-**v1.0.5 "Coronation"** | **FREE AND OPEN SOURCE** | **GPL v2**
+**v1.0.6 "Coronation"** | **FREE AND OPEN SOURCE** | **GPL v2**
 
 130+ autonomous NPCs wake up, go to work, visit taverns, fall in love, get married, have children, age, and eventually die of old age, all while you're offline. Log back in, read the news feed, and discover that the blacksmith married the barmaid, the king was assassinated, or a new generation just came of age. The world doesn't wait for you.
 
@@ -330,7 +330,7 @@ Join Discord for discussions, feedback, and updates: **https://discord.gg/EZhwgD
 
 *"You are not a wave fighting the ocean. You ARE the ocean, dreaming of being a wave."*
 
-## Known Issues (v1.0.5)
+## Known Issues (v1.0.6)
 
 - Save files from the earliest alpha versions may not be fully compatible.
 - BBS FOSSIL mode not natively supported (use `--stdio` flag for FOSSIL-based BBSes via host pipe).
@@ -343,4 +343,4 @@ Join Discord for discussions, feedback, and updates: **https://discord.gg/EZhwgD
 
 ---
 
-**Status:** v1.0.5 "Coronation". The world is running. [Watch it live.](https://usurper-reborn.net)
+**Status:** v1.0.6 "Coronation". The world is running. [Watch it live.](https://usurper-reborn.net)

--- a/Scripts/Core/GameConfig.cs
+++ b/Scripts/Core/GameConfig.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 public static partial class GameConfig
 {
     // Version information
-    public const string Version = "1.0.5";
+    public const string Version = "1.0.6";
     public const string VersionName = "Coronation"; // 1.0 release
 
     // v0.57.12: Alignment scale cap. Character.Chivalry and Character.Darkness setters clamp to [0, AlignmentCap]

--- a/Scripts/Server/MudServer.cs
+++ b/Scripts/Server/MudServer.cs
@@ -1112,9 +1112,12 @@ public class MudServer
 
             // v1.0.6: the probe window closing throws OperationCanceledException out of
             // ReadAsync. That used to escape to the outer catch and skip the result block
-            // below, so a terminal type or GMCP answer that had already arrived was
-            // discarded: CP437 terminals (SyncTerm, NetRunner) got UTF-8 box glyphs and
-            // GMCP never negotiated. The window closing is the normal end of the probe.
+            // below, so a terminal type that had already arrived was discarded:
+            // CP437 terminals (SyncTerm, NetRunner) got UTF-8 box glyphs and screen
+            // readers never got plain-text mode. (GMCP and DONT ECHO were unaffected;
+            // they live outside the try and ride the fallback return.) The window
+            // closing is the normal end of the probe; the two SB drain loops read on
+            // the same token so a client that never sends IAC SE cannot park the probe.
             try
             {
             while (!ttypeCts.Token.IsCancellationRequested)
@@ -1148,12 +1151,12 @@ public class MudServer
                     {
                         if (await stream.ReadAsync(buf, 0, 1, ttypeCts.Token) == 0) break;
                         // buf[0] should be 0x00 (IS) — consume and read the type string
-                        while (!ct.IsCancellationRequested)
+                        while (!ttypeCts.Token.IsCancellationRequested)
                         {
-                            if (await stream.ReadAsync(buf, 0, 1, ct) == 0) break;
+                            if (await stream.ReadAsync(buf, 0, 1, ttypeCts.Token) == 0) break;
                             if (buf[0] == 0xFF) // IAC inside SB
                             {
-                                if (await stream.ReadAsync(buf, 0, 1, ct) == 0) break;
+                                if (await stream.ReadAsync(buf, 0, 1, ttypeCts.Token) == 0) break;
                                 if (buf[0] == 0xF0) break; // SE — end of subneg
                             }
                             else
@@ -1167,12 +1170,12 @@ public class MudServer
                     else
                     {
                         // Different option in SB — drain until IAC SE
-                        while (!ct.IsCancellationRequested)
+                        while (!ttypeCts.Token.IsCancellationRequested)
                         {
-                            if (await stream.ReadAsync(buf, 0, 1, ct) == 0) break;
+                            if (await stream.ReadAsync(buf, 0, 1, ttypeCts.Token) == 0) break;
                             if (buf[0] == 0xFF)
                             {
-                                if (await stream.ReadAsync(buf, 0, 1, ct) == 0) break;
+                                if (await stream.ReadAsync(buf, 0, 1, ttypeCts.Token) == 0) break;
                                 if (buf[0] == 0xF0) break;
                             }
                         }

--- a/Scripts/Server/MudServer.cs
+++ b/Scripts/Server/MudServer.cs
@@ -538,6 +538,7 @@ public class MudServer
             bool isPlainText = false;
             bool isCp437 = false;
             bool gmcpEnabled = false;
+            bool wantsServerEcho = false;
 
             if (isInteractive)
             {
@@ -616,6 +617,8 @@ public class MudServer
                     username = parts[1].Trim();
                     connectionType = parts[2].Trim();
                 }
+
+                connectionType = ParseConnectionTypeParams(connectionType, out wantsServerEcho);
 
                 var usernameKey = username.ToLowerInvariant();
                 Console.Error.WriteLine($"[MUD] Connection from {client.Client.RemoteEndPoint}: user={username}, type={connectionType}, auth={( password != null ? (isRegistration ? "register" : "password") : "trusted" )}");
@@ -730,7 +733,8 @@ public class MudServer
                     isPlainText: isPlainText,
                     isCp437: isCp437,
                     gmcpEnabled: gmcpEnabled,
-                    forwardedIP: forwardedIP
+                    forwardedIP: forwardedIP,
+                    wantsServerEcho: wantsServerEcho
                 );
                 session.ClientVersion = clientVersion;
 
@@ -1509,6 +1513,28 @@ public class MudServer
     }
 
     /// <summary>Send a message to a specific player by username.</summary>
+    /// <summary>
+    /// v1.0.6: the AUTH connection type may carry ";key=value" parameters after the
+    /// type name, e.g. "SSH;echo=1" from a relay that has put its PTY in raw mode and
+    /// wants the server to echo. Parameters ride inside the existing field so an older
+    /// server just stores the odd type string and keeps working; only "echo" is known.
+    /// </summary>
+    internal static string ParseConnectionTypeParams(string? connectionType, out bool wantsServerEcho)
+    {
+        wantsServerEcho = false;
+        if (string.IsNullOrEmpty(connectionType)) return "";
+        int semi = connectionType.IndexOf(';');
+        if (semi < 0) return connectionType.Trim();
+        var parts = connectionType.Split(';');
+        for (int i = 1; i < parts.Length; i++)
+        {
+            var kv = parts[i].Split('=', 2);
+            if (kv.Length == 2 && kv[0].Trim().Equals("echo", StringComparison.OrdinalIgnoreCase) && kv[1].Trim() == "1")
+                wantsServerEcho = true;
+        }
+        return parts[0].Trim();
+    }
+
     public bool SendToPlayer(string username, string message)
     {
         if (ActiveSessions.TryGetValue(username.ToLowerInvariant(), out var session))

--- a/Scripts/Server/MudServer.cs
+++ b/Scripts/Server/MudServer.cs
@@ -1110,6 +1110,13 @@ public class MudServer
             var ttype = new System.Text.StringBuilder();
             bool gotTtype = false;
 
+            // v1.0.6: the probe window closing throws OperationCanceledException out of
+            // ReadAsync. That used to escape to the outer catch and skip the result block
+            // below, so a terminal type or GMCP answer that had already arrived was
+            // discarded: CP437 terminals (SyncTerm, NetRunner) got UTF-8 box glyphs and
+            // GMCP never negotiated. The window closing is the normal end of the probe.
+            try
+            {
             while (!ttypeCts.Token.IsCancellationRequested)
             {
                 int read = await stream.ReadAsync(buf, 0, 1, ttypeCts.Token);
@@ -1171,6 +1178,11 @@ public class MudServer
                         }
                     }
                 }
+            }
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // Probe window closed; evaluate whatever arrived before it did.
             }
 
             if (gotTtype && ttype.Length > 0)

--- a/Scripts/Server/PlayerSession.cs
+++ b/Scripts/Server/PlayerSession.cs
@@ -94,6 +94,9 @@ public class PlayerSession : IDisposable
     /// <summary>True while this session is in spectator mode (no game loaded).</summary>
     public bool IsSpectating { get; set; }
 
+    /// <summary>v1.0.6: the relay put its terminal in raw mode and asked the server to echo (AUTH type ";echo=1").</summary>
+    public bool WantsServerEcho { get; }
+
     /// <summary>Pending spectate request awaiting this player's /accept or /deny.</summary>
     public SpectateRequest? PendingSpectateRequest { get; set; }
 
@@ -127,9 +130,11 @@ public class PlayerSession : IDisposable
         bool isPlainText = false,
         bool isCp437 = false,
         bool gmcpEnabled = false,
-        string? forwardedIP = null)
+        string? forwardedIP = null,
+        bool wantsServerEcho = false)
     {
         Username = username;
+        WantsServerEcho = wantsServerEcho;
         ActiveCharacterName = username;
         ConnectionType = connectionType;
         _tcpClient = tcpClient;
@@ -202,11 +207,15 @@ public class PlayerSession : IDisposable
             // see the framing bytes.
             ctx.GmcpEnabled = _gmcpEnabled;
 
-            // ServerEchoes: true only for direct raw-TCP MUD connections (Mudlet, etc.)
-            // where we sent IAC WILL ECHO and the client disabled its local echo.
-            // SSH relay connections (web terminal, direct SSH) use PTY echo — server
-            // must not double-echo or every character appears twice in the terminal.
-            ctx.Terminal.ServerEchoes = (ConnectionType == "MUD");
+            // ServerEchoes: the server owns the input line (echoes keystrokes, and can
+            // erase-and-redraw the line when a message lands mid-typing) for:
+            //  - direct raw-TCP MUD clients (Mudlet etc.), which answered IAC WILL ECHO;
+            //  - the web terminal (v1.0.6): xterm.js streams keystrokes and never echoes
+            //    locally, so web players were typing blind in game until now;
+            //  - the SSH relay when it has put its PTY in raw mode (v1.0.6, ";echo=1").
+            // Desktop/Steam, BBS door, and Electron clients keep their own line editor
+            // and local echo; the server must not echo for them or text doubles.
+            ctx.Terminal.ServerEchoes = ConnectionType == "MUD" || ConnectionType == "Web" || WantsServerEcho;
 
             // Enable real-time message delivery: terminal polls this during GetInput()
             ctx.Terminal.MessageSource = () =>

--- a/Scripts/Server/RelayClient.cs
+++ b/Scripts/Server/RelayClient.cs
@@ -32,7 +32,7 @@ public static class RelayClient
         // If the user is pre-authenticated (e.g. --user flag), connect directly
         if (!string.IsNullOrEmpty(username) && username != "anonymous")
         {
-            await ConnectAndBridge(username, null, port, connectionType, ct);
+            await ConnectAndBridge(username, null, port, connectionType, ct, rawTerminal: true);
             return;
         }
 
@@ -129,7 +129,7 @@ public static class RelayClient
             // ConnectAndBridge returns true if successfully connected and played,
             // false if auth failed (we should retry)
             bool isReg = choiceUpper == "R";
-            bool connected = await ConnectAndBridge(authUsername!, authPassword, port, connectionType, ct, isRegistration: isReg);
+            bool connected = await ConnectAndBridge(authUsername!, authPassword, port, connectionType, ct, isRegistration: isReg, rawTerminal: true);
             if (connected)
                 return; // Session completed (player quit or disconnected)
 
@@ -200,11 +200,22 @@ public static class RelayClient
     /// Connect to the MUD server, authenticate, and bridge stdin/stdout.
     /// Returns true if the session ran (even if it ended), false if auth failed.
     /// </summary>
+    /// <param name="rawTerminal">
+    /// v1.0.6: true for a human at the auth menu (or --user). If stdin is a real
+    /// terminal the relay switches it to raw, no-echo mode, forwards keystrokes one
+    /// at a time, and asks the server to echo (";echo=1"). The server then owns the
+    /// input line and can redraw it correctly when a message lands mid-typing.
+    /// Before this, .NET's console reader held each line locally until Enter and
+    /// echoed it itself; the server's erase-and-redraw wiped text it had never seen.
+    /// False for the AUTH: passthrough used by the desktop and BBS clients, which
+    /// keep their own line editors.
+    /// </param>
     private static async Task<bool> ConnectAndBridge(
         string username, string? password, int port, string connectionType, CancellationToken ct,
-        bool isRegistration = false)
+        bool isRegistration = false, bool rawTerminal = false)
     {
         TcpClient? client = null;
+        IDisposable? rawMode = null;
         try
         {
             client = new TcpClient();
@@ -212,6 +223,16 @@ public static class RelayClient
             client.NoDelay = true;
 
             var stream = client.GetStream();
+
+            if (rawTerminal && !Console.IsInputRedirected)
+            {
+                rawMode = TerminalRawMode.TryEnter();
+                if (rawMode != null)
+                {
+                    connectionType += ";echo=1";
+                    Console.Error.WriteLine("[RELAY] Terminal in raw mode; server-side echo requested");
+                }
+            }
 
             // Forward real client IP from SSH_CLIENT env var (format: "client_ip client_port server_port")
             var sshClient = Environment.GetEnvironmentVariable("SSH_CLIENT");
@@ -277,7 +298,12 @@ public static class RelayClient
                 try
                 {
                     var buffer = new byte[4096];
-                    var stdin = Console.OpenStandardInput();
+                    // Console.OpenStandardInput() on a terminal is .NET's line-mode reader
+                    // (holds the line, echoes locally). In raw mode read fd 0 directly so
+                    // each keystroke goes straight to the server.
+                    using Stream stdin = rawMode != null
+                        ? new FileStream(new Microsoft.Win32.SafeHandles.SafeFileHandle((IntPtr)0, ownsHandle: false), FileAccess.Read, bufferSize: 1, isAsync: false)
+                        : Console.OpenStandardInput();
                     while (!linkedCts.Token.IsCancellationRequested)
                     {
                         int read = await stdin.ReadAsync(buffer, 0, buffer.Length, linkedCts.Token);
@@ -335,6 +361,7 @@ public static class RelayClient
         }
         finally
         {
+            rawMode?.Dispose();
             client?.Close();
         }
     }

--- a/Scripts/Server/TerminalRawMode.cs
+++ b/Scripts/Server/TerminalRawMode.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace UsurperRemake.Server;
+
+/// <summary>
+/// v1.0.6: puts the relay's controlling terminal into raw, no-echo mode so that
+/// keystrokes reach the MUD server one at a time and the server can own the input
+/// line (echo, and erase-and-redraw when a message lands mid-typing).
+///
+/// Why P/Invoke rather than spawning stty: on Unix the .NET runtime restores its
+/// saved termios around every child process it starts, so a child's change is
+/// undone the moment it exits. Linux only; other platforms return null and the
+/// relay keeps its line-mode behaviour.
+///
+/// struct termios (glibc, x86_64 and aarch64): c_iflag@0 c_oflag@4 c_cflag@8
+/// c_lflag@12 (uint32 each), c_line@16, c_cc[32]@17, c_ispeed@52, c_ospeed@56.
+/// </summary>
+internal static class TerminalRawMode
+{
+    private const int STDIN_FILENO = 0;
+    private const int TCSANOW = 0;
+    private const uint ICANON = 0x0002;
+    private const uint ECHO = 0x0008;
+    private const int LFLAG_OFFSET = 12;
+    private const int CC_OFFSET = 17;
+    private const int VTIME = 5;
+    private const int VMIN = 6;
+    private const int TermiosBufferSize = 128; // real size is 60; over-allocate defensively
+
+    [DllImport("libc", SetLastError = true)] private static extern int tcgetattr(int fd, byte[] termios);
+    [DllImport("libc", SetLastError = true)] private static extern int tcsetattr(int fd, int optionalActions, byte[] termios);
+    [DllImport("libc")] private static extern int isatty(int fd);
+
+    public static bool IsSupported => OperatingSystem.IsLinux();
+
+    /// <summary>Enter raw mode on stdin. Returns a restorer, or null if stdin is not a terminal or the call failed.</summary>
+    public static IDisposable? TryEnter()
+    {
+        if (!IsSupported) return null;
+        try
+        {
+            if (isatty(STDIN_FILENO) != 1) return null;
+            var original = new byte[TermiosBufferSize];
+            if (tcgetattr(STDIN_FILENO, original) != 0) return null;
+
+            var raw = (byte[])original.Clone();
+            uint lflag = BitConverter.ToUInt32(raw, LFLAG_OFFSET);
+            lflag &= ~(ICANON | ECHO);
+            BitConverter.GetBytes(lflag).CopyTo(raw, LFLAG_OFFSET);
+            raw[CC_OFFSET + VMIN] = 1;
+            raw[CC_OFFSET + VTIME] = 0;
+            if (tcsetattr(STDIN_FILENO, TCSANOW, raw) != 0) return null;
+            return new Restorer(original);
+        }
+        catch
+        {
+            return null; // libc missing or layout mismatch: fall back to line mode
+        }
+    }
+
+    private sealed class Restorer : IDisposable
+    {
+        private byte[]? _original;
+        private readonly EventHandler _onExit;
+
+        public Restorer(byte[] original)
+        {
+            _original = original;
+            _onExit = (_, _) => Dispose();
+            AppDomain.CurrentDomain.ProcessExit += _onExit;
+        }
+
+        public void Dispose()
+        {
+            var orig = _original;
+            if (orig == null) return;
+            _original = null;
+            AppDomain.CurrentDomain.ProcessExit -= _onExit;
+            try { tcsetattr(STDIN_FILENO, TCSANOW, orig); } catch { }
+        }
+    }
+}

--- a/Scripts/Systems/OnlinePlaySystem.cs
+++ b/Scripts/Systems/OnlinePlaySystem.cs
@@ -284,9 +284,12 @@ namespace UsurperRemake.Systems
         private void FlushPendingRedraw(StringBuilder inputBuffer)
         {
             if (!_redrawPending) return;
-            _redrawPending = false;
-            if (inputBuffer.Length == 0) return;
-            lock (_consoleLock) Console.Write(inputBuffer.ToString());
+            lock (_consoleLock)
+            {
+                if (!_redrawPending) return;
+                if (inputBuffer.Length > 0) Console.Write(inputBuffer.ToString());
+                _redrawPending = false; // cleared after the write, under the same lock the receive side sets it
+            }
         }
 
         private static readonly System.Text.RegularExpressions.Regex AnsiSequence =
@@ -973,15 +976,17 @@ namespace UsurperRemake.Systems
                                 {
                                     if (vtProcessingEnabled) Console.Write(text);
                                     else WriteAnsiToConsole(text);
-                                }
-                                if (_pendingInput.Length > 0)
-                                {
-                                    // Re-show the half-typed line only when a prompt is showing,
-                                    // i.e. the visible text of this chunk does not end in a
-                                    // newline. The game pauses inside its own output (combat
-                                    // beats), so "output went quiet" alone is not a prompt.
-                                    _lastOutputUtc = DateTime.UtcNow;
-                                    _redrawPending = !VisibleTextEndsWithNewline(text);
+                                    if (_pendingInput.Length > 0)
+                                    {
+                                        // Re-show the half-typed line only when a prompt is showing,
+                                        // i.e. the visible text of this chunk does not end in a
+                                        // newline. The game pauses inside its own output (combat
+                                        // beats), so "output went quiet" alone is not a prompt.
+                                        // Flag is set under the console lock so a flush in progress
+                                        // on the input thread cannot be followed by a second print.
+                                        _lastOutputUtc = DateTime.UtcNow;
+                                        _redrawPending = !VisibleTextEndsWithNewline(text);
+                                    }
                                 }
                             }
                         }

--- a/Scripts/Systems/OnlinePlaySystem.cs
+++ b/Scripts/Systems/OnlinePlaySystem.cs
@@ -35,6 +35,13 @@ namespace UsurperRemake.Systems
         // Shared
         private CancellationTokenSource? cancellationSource;
         private bool vtProcessingEnabled = false;
+
+        // v1.0.6: the line being typed locally (Local/Steam mode). When server output
+        // lands mid-line the server no longer erases it (it never saw it); after the
+        // output goes quiet we re-show it under the fresh prompt.
+        private readonly StringBuilder _pendingInput = new();
+        private volatile bool _redrawPending;
+        private DateTime _lastOutputUtc;
         private bool useTcpMode = false;
         private string? _authLeftover; // Game data that arrived in the same chunk as the auth OK response
 
@@ -948,6 +955,11 @@ namespace UsurperRemake.Systems
                             {
                                 WriteAnsiToConsole(text);
                             }
+                            if (!UsurperRemake.BBS.DoorMode.IsInDoorMode && _pendingInput.Length > 0)
+                            {
+                                _lastOutputUtc = DateTime.UtcNow;
+                                _redrawPending = true; // input loop re-shows the line once output is quiet
+                            }
                         }
                     }
                 }
@@ -1023,7 +1035,9 @@ namespace UsurperRemake.Systems
                 {
                     // Local/Steam mode: poll Console.KeyAvailable for non-blocking char-by-char input.
                     // Ctrl+] disconnects (classic telnet escape).
-                    var inputBuffer = new StringBuilder();
+                    var inputBuffer = _pendingInput;
+                    inputBuffer.Clear();
+                    _redrawPending = false;
                     while (!ct.IsCancellationRequested)
                     {
                         if (readTask.IsCompleted || serverDead[0])
@@ -1051,6 +1065,7 @@ namespace UsurperRemake.Systems
                                 }
                                 Console.Write("\r\n"); // Local newline echo
                                 inputBuffer.Clear();
+                                _redrawPending = false;
                             }
                             else if (keyInfo.Key == ConsoleKey.Backspace)
                             {
@@ -1069,6 +1084,15 @@ namespace UsurperRemake.Systems
                         }
                         else
                         {
+                            // v1.0.6: server output (a room render arrives in several TCP
+                            // reads) has been quiet for a moment and we have a half-typed
+                            // line: print it again after the prompt the server just drew.
+                            if (_redrawPending && (DateTime.UtcNow - _lastOutputUtc).TotalMilliseconds >= 60)
+                            {
+                                _redrawPending = false;
+                                if (inputBuffer.Length > 0)
+                                    Console.Write(inputBuffer.ToString());
+                            }
                             await Task.Delay(10, ct);
                         }
                     }

--- a/Scripts/Systems/OnlinePlaySystem.cs
+++ b/Scripts/Systems/OnlinePlaySystem.cs
@@ -42,6 +42,7 @@ namespace UsurperRemake.Systems
         private readonly StringBuilder _pendingInput = new();
         private volatile bool _redrawPending;
         private DateTime _lastOutputUtc;
+        private readonly object _consoleLock = new(); // receive thread and input thread both write the console
         private bool useTcpMode = false;
         private string? _authLeftover; // Game data that arrived in the same chunk as the auth OK response
 
@@ -279,6 +280,25 @@ namespace UsurperRemake.Systems
         /// <summary>
         /// Write a string to the active connection (SSH shell stream or TCP stream).
         /// </summary>
+        /// <summary>v1.0.6: print the half-typed line again after the prompt the server just drew.</summary>
+        private void FlushPendingRedraw(StringBuilder inputBuffer)
+        {
+            if (!_redrawPending) return;
+            _redrawPending = false;
+            if (inputBuffer.Length == 0) return;
+            lock (_consoleLock) Console.Write(inputBuffer.ToString());
+        }
+
+        private static readonly System.Text.RegularExpressions.Regex AnsiSequence =
+            new(@"\x1b\[[0-9;?]*[A-Za-z]", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+        /// <summary>True when the last visible character of a server chunk is a newline (no prompt showing).</summary>
+        private static bool VisibleTextEndsWithNewline(string chunk)
+        {
+            var visible = AnsiSequence.Replace(chunk, "").TrimEnd(' ');
+            return visible.Length == 0 || visible[^1] == '\n';
+        }
+
         private void WriteToServer(string text)
         {
             if (useTcpMode && tcpStream != null)
@@ -947,18 +967,22 @@ namespace UsurperRemake.Systems
                             {
                                 terminal.WriteRawAnsi(text);
                             }
-                            else if (vtProcessingEnabled)
-                            {
-                                Console.Write(text);
-                            }
                             else
                             {
-                                WriteAnsiToConsole(text);
-                            }
-                            if (!UsurperRemake.BBS.DoorMode.IsInDoorMode && _pendingInput.Length > 0)
-                            {
-                                _lastOutputUtc = DateTime.UtcNow;
-                                _redrawPending = true; // input loop re-shows the line once output is quiet
+                                lock (_consoleLock)
+                                {
+                                    if (vtProcessingEnabled) Console.Write(text);
+                                    else WriteAnsiToConsole(text);
+                                }
+                                if (_pendingInput.Length > 0)
+                                {
+                                    // Re-show the half-typed line only when a prompt is showing,
+                                    // i.e. the visible text of this chunk does not end in a
+                                    // newline. The game pauses inside its own output (combat
+                                    // beats), so "output went quiet" alone is not a prompt.
+                                    _lastOutputUtc = DateTime.UtcNow;
+                                    _redrawPending = !VisibleTextEndsWithNewline(text);
+                                }
                             }
                         }
                     }
@@ -1071,14 +1095,18 @@ namespace UsurperRemake.Systems
                             {
                                 if (inputBuffer.Length > 0)
                                 {
+                                    FlushPendingRedraw(inputBuffer);
                                     inputBuffer.Remove(inputBuffer.Length - 1, 1);
-                                    Console.Write("\b \b");
+                                    lock (_consoleLock) Console.Write("\b \b");
                                 }
                             }
                             else if (keyInfo.KeyChar >= ' ' && keyInfo.KeyChar != '\x7f')
                             {
+                                // A key inside the redraw window: show the old text first so
+                                // the line does not read "> lhello worl".
+                                FlushPendingRedraw(inputBuffer);
                                 inputBuffer.Append(keyInfo.KeyChar);
-                                Console.Write(keyInfo.KeyChar);
+                                lock (_consoleLock) Console.Write(keyInfo.KeyChar);
                             }
                             // Non-printable keys (arrows, escape, tab) are ignored
                         }
@@ -1088,11 +1116,7 @@ namespace UsurperRemake.Systems
                             // reads) has been quiet for a moment and we have a half-typed
                             // line: print it again after the prompt the server just drew.
                             if (_redrawPending && (DateTime.UtcNow - _lastOutputUtc).TotalMilliseconds >= 60)
-                            {
-                                _redrawPending = false;
-                                if (inputBuffer.Length > 0)
-                                    Console.Write(inputBuffer.ToString());
-                            }
+                                FlushPendingRedraw(inputBuffer);
                             await Task.Delay(10, ct);
                         }
                     }

--- a/Scripts/UI/OutputLineTracker.cs
+++ b/Scripts/UI/OutputLineTracker.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Text;
+
+/// <summary>
+/// v1.0.6: remembers the text the game has written on the current output line
+/// (everything since the last newline, carriage return, or clear), so that when a
+/// chat or world message arrives while the player is typing, the terminal can
+/// redraw the real prompt line afterwards. Before this the redraw printed
+/// GetInput's <c>prompt</c> argument, which is usually empty or "Your choice:",
+/// while the visible prompt ("[25hp 100st] Main Street >") had been written
+/// separately and was lost after every message.
+///
+/// Only SGR colour sequences are kept; cursor movement and erase sequences are
+/// dropped so the stored line can be replayed verbatim. ESC[2J and ESC[2K empty it.
+/// </summary>
+public sealed class OutputLineTracker
+{
+    private const int MaxLength = 1024;
+    private readonly StringBuilder _line = new();
+    private readonly object _lock = new();
+    private int _csiStart = -1;   // index in _line of a pending ESC, -1 when not inside a sequence
+    private bool _csiHasBracket;
+
+    /// <summary>When true, writes are not tracked (server echo of keystrokes, the redraw itself).</summary>
+    public bool Suppress { get; set; }
+
+    public string CurrentLine
+    {
+        get { lock (_lock) return _csiStart >= 0 ? _line.ToString(0, _csiStart) : _line.ToString(); }
+    }
+
+    public void Reset()
+    {
+        lock (_lock) { _line.Clear(); _csiStart = -1; }
+    }
+
+    public void Track(char c)
+    {
+        if (Suppress) return;
+        lock (_lock) TrackCore(c);
+    }
+
+    public void Track(string? text)
+    {
+        if (Suppress || string.IsNullOrEmpty(text)) return;
+        lock (_lock)
+        {
+            foreach (var c in text) TrackCore(c);
+        }
+    }
+
+    private void TrackCore(char c)
+    {
+        if (_csiStart >= 0)
+        {
+            _line.Append(c);
+            if (!_csiHasBracket)
+            {
+                if (c == '[') { _csiHasBracket = true; return; }
+                // ESC followed by something other than '[' (e.g. ESC 7): not a CSI, drop it.
+                _line.Length = _csiStart; _csiStart = -1; return;
+            }
+            if (c >= '@' && c <= '~')
+            {
+                // Final byte. Keep colour (m), drop everything else; 2J / 2K also empty the line.
+                bool clearAll = (c == 'J' || c == 'K') && _line.Length - _csiStart == 4 && _line[_csiStart + 2] == '2';
+                if (c != 'm') _line.Length = _csiStart;
+                _csiStart = -1;
+                if (clearAll) _line.Clear();
+            }
+            return;
+        }
+
+        if (c == '\n' || c == '\r') { _line.Clear(); return; }
+        if (c == '\x1b') { _csiStart = _line.Length; _csiHasBracket = false; _line.Append(c); return; }
+        _line.Append(c);
+        if (_line.Length > MaxLength) _line.Remove(0, _line.Length - MaxLength);
+    }
+}
+
+/// <summary>
+/// StreamWriter that feeds every write through an <see cref="OutputLineTracker"/>.
+/// The span overload is deliberately not overridden: StreamWriter routes it to
+/// Write(char[], int, int) for subclasses, so tracking it too would double-count.
+/// </summary>
+internal sealed class LineTrackingStreamWriter : StreamWriter
+{
+    private readonly OutputLineTracker _tracker;
+
+    public LineTrackingStreamWriter(Stream stream, Encoding encoding, OutputLineTracker tracker) : base(stream, encoding)
+    {
+        _tracker = tracker;
+    }
+
+    public override void Write(char value) { _tracker.Track(value); base.Write(value); }
+    public override void Write(string? value) { _tracker.Track(value); base.Write(value); }
+    public override void Write(char[]? buffer) { if (buffer != null) _tracker.Track(new string(buffer)); base.Write(buffer); }
+    public override void Write(char[] buffer, int index, int count) { _tracker.Track(new string(buffer, index, count)); base.Write(buffer, index, count); }
+    public override void WriteLine(string? value) { _tracker.Track(value); _tracker.Track('\n'); base.WriteLine(value); }
+    public override void WriteLine() { _tracker.Track('\n'); base.WriteLine(); }
+}

--- a/Scripts/UI/OutputLineTracker.cs
+++ b/Scripts/UI/OutputLineTracker.cs
@@ -20,7 +20,6 @@ public sealed class OutputLineTracker
     private readonly StringBuilder _line = new();
     private readonly object _lock = new();
     private int _csiStart = -1;   // index in _line of a pending ESC, -1 when not inside a sequence
-    private bool _csiHasBracket;
 
     /// <summary>When true, writes are not tracked (server echo of keystrokes, the redraw itself).</summary>
     public bool Suppress { get; set; }
@@ -32,7 +31,7 @@ public sealed class OutputLineTracker
 
     public void Reset()
     {
-        lock (_lock) { _line.Clear(); _csiStart = -1; }
+        lock (_lock) { _line.Clear(); _csiStart = -1; _escMode = 0; }
     }
 
     public void Track(char c)
@@ -50,32 +49,61 @@ public sealed class OutputLineTracker
         }
     }
 
+    // Escape-sequence state: 0 = text, 1 = after ESC, 2 = CSI (ESC [), 3 = OSC (ESC ]),
+    // 4 = one-byte intermediate (ESC ( / ESC ) charset selects and similar).
+    private int _escMode;
+    private bool _oscEsc; // inside OSC, previous char was ESC (looking for the ST terminator ESC \)
+
     private void TrackCore(char c)
     {
-        if (_csiStart >= 0)
+        switch (_escMode)
         {
-            _line.Append(c);
-            if (!_csiHasBracket)
-            {
-                if (c == '[') { _csiHasBracket = true; return; }
-                // ESC followed by something other than '[' (e.g. ESC 7): not a CSI, drop it.
-                _line.Length = _csiStart; _csiStart = -1; return;
-            }
-            if (c >= '@' && c <= '~')
-            {
-                // Final byte. Keep colour (m), drop everything else; 2J / 2K also empty the line.
-                bool clearAll = (c == 'J' || c == 'K') && _line.Length - _csiStart == 4 && _line[_csiStart + 2] == '2';
-                if (c != 'm') _line.Length = _csiStart;
-                _csiStart = -1;
-                if (clearAll) _line.Clear();
-            }
-            return;
+            case 1: // after ESC
+                _line.Append(c);
+                if (c == '[') { _escMode = 2; return; }
+                if (c == ']') { _escMode = 3; _oscEsc = false; return; }
+                if (c == '(' || c == ')' || c == '#' || c == '%') { _escMode = 4; return; }
+                // Two-byte escape (ESC 7, ESC =, ...): drop it whole.
+                _line.Length = _csiStart; _csiStart = -1; _escMode = 0;
+                return;
+            case 2: // CSI
+                _line.Append(c);
+                if (c >= '@' && c <= '~')
+                {
+                    // Final byte. Keep colour (m), drop everything else; 2J / 2K also empty the line.
+                    bool clearAll = (c == 'J' || c == 'K') && _line.Length - _csiStart == 4 && _line[_csiStart + 2] == '2';
+                    if (c != 'm') _line.Length = _csiStart;
+                    _csiStart = -1; _escMode = 0;
+                    if (clearAll) _line.Clear();
+                }
+                return;
+            case 3: // OSC: runs to BEL or ESC \ ; never part of a prompt, drop it whole
+                if (c == '\x07' || (_oscEsc && c == '\\'))
+                {
+                    _line.Length = _csiStart; _csiStart = -1; _escMode = 0;
+                    return;
+                }
+                _oscEsc = c == '\x1b';
+                return;
+            case 4: // one intermediate byte then done
+                _line.Length = _csiStart; _csiStart = -1; _escMode = 0;
+                return;
         }
 
         if (c == '\n' || c == '\r') { _line.Clear(); return; }
-        if (c == '\x1b') { _csiStart = _line.Length; _csiHasBracket = false; _line.Append(c); return; }
+        if (c == '\x1b') { _csiStart = _line.Length; _escMode = 1; _line.Append(c); return; }
         _line.Append(c);
-        if (_line.Length > MaxLength) _line.Remove(0, _line.Length - MaxLength);
+        if (_line.Length > MaxLength)
+        {
+            // Trim from the front, but never inside an escape sequence: cut at the
+            // first ESC on or after the cut point when there is one.
+            int cut = _line.Length - MaxLength;
+            for (int k = cut; k < _line.Length; k++)
+            {
+                if (_line[k] == '\x1b') { cut = k; break; }
+            }
+            _line.Remove(0, cut);
+        }
     }
 }
 

--- a/Scripts/UI/OutputLineTracker.cs
+++ b/Scripts/UI/OutputLineTracker.cs
@@ -77,7 +77,9 @@ public sealed class OutputLineTracker
                     if (clearAll) _line.Clear();
                 }
                 return;
-            case 3: // OSC: runs to BEL or ESC \ ; never part of a prompt, drop it whole
+            case 3: // OSC: runs to BEL or ESC \ ; never part of a prompt, drop it whole.
+                    // An unterminated OSC would swallow text through newlines; nothing in
+                    // the game writes OSC to the stream, and Reset() at each read end bounds it.
                 if (c == '\x07' || (_oscEsc && c == '\\'))
                 {
                     _line.Length = _csiStart; _csiStart = -1; _escMode = 0;
@@ -96,7 +98,9 @@ public sealed class OutputLineTracker
         if (_line.Length > MaxLength)
         {
             // Trim from the front, but never inside an escape sequence: cut at the
-            // first ESC on or after the cut point when there is one.
+            // first ESC on or after the cut point when there is one. (A cut that
+            // lands inside a sequence with no later ESC would still leave a broken
+            // head; unreachable at this cap for any real prompt line.)
             int cut = _line.Length - MaxLength;
             for (int k = cut; k < _line.Length; k++)
             {

--- a/Scripts/UI/TerminalEmulator.cs
+++ b/Scripts/UI/TerminalEmulator.cs
@@ -93,6 +93,9 @@ public partial class TerminalEmulator
     /// </summary>
     public bool ServerEchoes { get; set; } = false;
 
+    /// <summary>v1.0.6: the text on the current output line, used to redraw the real prompt after a mid-input message.</summary>
+    private readonly OutputLineTracker _lineTracker = new();
+
     /// <summary>Returns true when this terminal is backed by a TCP stream (MUD mode).</summary>
     public bool IsStreamBacked => _streamWriter != null;
 
@@ -232,6 +235,7 @@ public partial class TerminalEmulator
     /// </summary>
     private void WriteCp437ToStream(string ansi, string? spectatorAnsi = null)
     {
+        _lineTracker.Track(ansi); // bypasses the tracking writer, so track here
         var translated = PreTranslateCp437(ansi);
         var bytes = Cp437Encoding.GetBytes(translated);
         _streamWriter!.BaseStream.Write(bytes, 0, bytes.Length);
@@ -262,7 +266,7 @@ public partial class TerminalEmulator
     public TerminalEmulator(System.IO.Stream inputStream, System.IO.Stream outputStream)
     {
         _streamReader = new StreamReader(inputStream, System.Text.Encoding.UTF8);
-        _streamWriter = new StreamWriter(outputStream, new System.Text.UTF8Encoding(false))
+        _streamWriter = new LineTrackingStreamWriter(outputStream, new System.Text.UTF8Encoding(false), _lineTracker)
         {
             AutoFlush = true,
             NewLine = "\r\n" // Telnet/terminal convention
@@ -2106,6 +2110,25 @@ public partial class TerminalEmulator
         }
         catch { }
 
+        // v1.0.6: what is on the prompt line right now (status prompt, "Press any
+        // key...", etc.) is what a mid-input redraw must restore. Snapshot it once;
+        // nothing written during the read (echo, the redraw itself) counts as prompt.
+        string promptLine = _lineTracker.CurrentLine;
+        _lineTracker.Suppress = true;
+        try
+        {
+            return await ReadLineInteractiveCore(promptLine);
+        }
+        finally
+        {
+            _lineTracker.Suppress = false;
+        }
+    }
+
+    private async Task<string> ReadLineInteractiveCore(string promptLine)
+    {
+        if (_streamReader == null || _streamWriter == null) return string.Empty;
+
         var buffer = new System.Text.StringBuilder();
         var charBuf = new char[1];
         int escState = 0; // 0 = normal, 1 = after ESC, 2 = inside CSI (ESC [)
@@ -2128,7 +2151,7 @@ public partial class TerminalEmulator
                 bool userIsTyping = buffer.Length > 0
                     && (DateTime.Now - lastKeystrokeTime).TotalMilliseconds < 500;
                 if (!userIsTyping)
-                    DeliverPendingMessagesWithRedraw(prompt, buffer);
+                    DeliverPendingMessagesWithRedraw(promptLine, buffer);
                 continue; // readTask is still the same pending call
             }
 
@@ -2239,38 +2262,44 @@ public partial class TerminalEmulator
     /// current input line, print all messages, then redraw prompt + typed buffer.
     /// Called from ReadLineInteractiveAsync on every 50 ms poll tick.
     /// </summary>
-    private void DeliverPendingMessagesWithRedraw(string prompt, System.Text.StringBuilder currentBuffer)
+    private void DeliverPendingMessagesWithRedraw(string promptLine, System.Text.StringBuilder currentBuffer)
     {
         if (MessageSource == null || _streamWriter == null) return;
 
-        bool anyMessages = false;
+        var pending = new List<string>();
         string? msg;
-        while ((msg = MessageSource()) != null)
-        {
-            if (!anyMessages)
-            {
-                // Erase the entire current line (prompt + whatever the player typed)
-                lock (_streamWriterLock)
-                    _streamWriter.Write("\r\x1b[2K");
-                anyMessages = true;
-            }
-            lock (_streamWriterLock)
-            {
-                _streamWriter.Write(msg);
-                _streamWriter.Write("\r\n\x1b[0m");
-            }
-        }
+        while ((msg = MessageSource()) != null) pending.Add(msg);
+        if (pending.Count == 0) return;
 
-        if (anyMessages)
+        // v1.0.6: two delivery modes, chosen by who owns the input line.
+        //  - Server-echo transports (MUD clients, the web terminal, the raw-mode SSH
+        //    relay): the server drew the prompt and every typed character, so it can
+        //    erase the line, print the messages, and redraw prompt + buffer exactly.
+        //  - Everything else (desktop/Steam client, BBS door, Electron): the client
+        //    holds and displays the typed text and the server has never seen it.
+        //    Erasing the line wiped text the client still held -- the "input
+        //    stomping" players reported -- and Enter then submitted the invisible
+        //    text. Now the server leaves that line alone, moves to a fresh line,
+        //    prints the messages, and redraws the prompt only; the desktop client
+        //    re-shows its own pending text underneath.
+        //  Screen-reader (plain text) sessions never receive erase sequences.
+        // The prompt line is the tracked output line, not GetInput's prompt argument,
+        // which was usually empty or "Your choice:" while the real prompt was lost.
+        bool eraseLine = ServerEchoes && !IsPlainText;
+        var sb = new System.Text.StringBuilder();
+        sb.Append(eraseLine ? "\r\x1b[2K" : "\r\n");
+        foreach (var m in pending)
         {
-            // Redraw prompt and restore the player's typed text
-            lock (_streamWriterLock)
-            {
-                _streamWriter.Write($"\x1b[{GetAnsiColorCode("bright_white")}m{prompt}\x1b[0m");
-                if (currentBuffer.Length > 0)
-                    _streamWriter.Write(currentBuffer.ToString());
-                _streamWriter.Flush();
-            }
+            sb.Append(m);
+            sb.Append("\r\n\x1b[0m");
+        }
+        sb.Append("\x1b[0m").Append(promptLine);
+        if (ServerEchoes && currentBuffer.Length > 0)
+            sb.Append(currentBuffer);
+
+        lock (_streamWriterLock)
+        {
+            WriteRawAnsi(sb.ToString()); // honours plain-text and CP437 modes, forwards to spectators
         }
     }
 

--- a/Scripts/UI/TerminalEmulator.cs
+++ b/Scripts/UI/TerminalEmulator.cs
@@ -2122,6 +2122,10 @@ public partial class TerminalEmulator
         finally
         {
             _lineTracker.Suppress = false;
+            // The Enter echo moved the cursor to a fresh line while tracking was
+            // suppressed; without this the old prompt would prefix whatever the
+            // game prints next without its own leading newline.
+            _lineTracker.Reset();
         }
     }
 

--- a/Tests/Harness/input-stomping/README.md
+++ b/Tests/Harness/input-stomping/README.md
@@ -30,8 +30,8 @@ presses Enter and prints what the server made of the input.
 |------|---------|------------------------------------|
 | MUD client (Mudlet, TinTin++; answers DO ECHO) | `python3 stomp.py MUD` | `\r\x1b[2K` + message + real prompt line + `hello wor` |
 | Web terminal (raw TCP, `X-Client:Web`, keystrokes streamed) | `python3 stomp.py WEB` | same as MUD; typing must echo (`bytes while typing` = `hello wor`) |
-| SyncTerm / CP437 (TTYPE reply `SYNCTERM`) | `python3 stomp.py SYNCTERM` | same as MUD |
-| Desktop / Steam / BBS door client (AUTH on TCP, whole lines, local echo) | `python3 stomp.py DESKTOP` | `\r\n` + message + real prompt line, no typed text, no erase |
+| SyncTerm / CP437 (TTYPE reply `SYNCTERM`) | `python3 stomp.py SYNCTERM` | same as MUD. Known gap: the scripted TTYPE reply does not currently trigger CP437 detection in `ProbeTtypeAsync`, so this case exercises the MUD path; CP437 translation is the shared `WriteRawAnsi` path |
+| Desktop / Steam / BBS door client (AUTH on TCP, whole lines, local echo) | `python3 stomp.py DESKTOP` | `\r\n` + message + real prompt line, no typed text, no erase. Server side only: the real client's re-echo of its own buffer (OnlinePlaySystem) is hand-verified, not driven here |
 | SSH through `--mud-relay` under a real PTY | `python3 relay_stomp.py` | same as MUD; PTY attrs must show ICANON and ECHO off |
 
 Pass criteria for every case: the message is on its own line, the prompt that was

--- a/Tests/Harness/input-stomping/README.md
+++ b/Tests/Harness/input-stomping/README.md
@@ -1,0 +1,48 @@
+# Input-stomping harness
+
+Scripted clients that reproduce "a message arrived while I was typing" against a
+local MUD server, one per transport the game supports. Built for the v1.0.6 fix;
+keep it green whenever `TerminalEmulator.ReadLineInteractiveAsync`,
+`DeliverPendingMessagesWithRedraw`, `PlayerSession.ServerEchoes`, or the relay change.
+
+## Setup
+
+```
+dotnet build usurper-reloaded.csproj -c Release
+mkdir -p /tmp/usurper-harness && cd /tmp/usurper-harness
+/path/to/bin/Release/net8.0/UsurperReborn --mud-server --mud-port 4999 --db ./test.db &
+cd /path/to/repo/Tests/Harness/input-stomping
+python3 auto.py alpha secret123 Alpha register    # creates account + character, quick start
+python3 auto.py beta  secret123 Beta  register
+```
+
+`USURPER_PORT` (default 4999) and `USURPER_EXE` (default `../../bin/Release/net8.0/UsurperReborn`)
+override the server port and the relay binary.
+
+## Cases
+
+Each case logs `alpha` in on the transport under test, logs `beta` in as a MUD
+client, types `hello wor` on alpha without pressing Enter, has beta send
+`/tell Alpha ping`, and prints the raw bytes alpha's screen received. Then it
+presses Enter and prints what the server made of the input.
+
+| Case | Command | Expected bytes when the tell lands |
+|------|---------|------------------------------------|
+| MUD client (Mudlet, TinTin++; answers DO ECHO) | `python3 stomp.py MUD` | `\r\x1b[2K` + message + real prompt line + `hello wor` |
+| Web terminal (raw TCP, `X-Client:Web`, keystrokes streamed) | `python3 stomp.py WEB` | same as MUD; typing must echo (`bytes while typing` = `hello wor`) |
+| SyncTerm / CP437 (TTYPE reply `SYNCTERM`) | `python3 stomp.py SYNCTERM` | same as MUD |
+| Desktop / Steam / BBS door client (AUTH on TCP, whole lines, local echo) | `python3 stomp.py DESKTOP` | `\r\n` + message + real prompt line, no typed text, no erase |
+| SSH through `--mud-relay` under a real PTY | `python3 relay_stomp.py` | same as MUD; PTY attrs must show ICANON and ECHO off |
+
+Pass criteria for every case: the message is on its own line, the prompt that was
+on screen before the message is redrawn exactly, and the typed text appears at most
+once (exactly once on echo transports, zero times on the desktop path, where the
+client re-shows its own buffer).
+
+The real web page can be driven too: run `web/ssh-proxy.js` with
+`MUD_MODE=1 MUD_PORT=4999 DB_PATH=/tmp/usurper-harness/test.db`, add your origin to
+`ALLOWED_ORIGINS`, and repeat the WEB case by hand in a browser.
+
+Not covered: a spectator typing while the spectated player's screen renders, and a
+browser resize mid-typing (the proxy now drops the resize control message; verify
+by resizing the window and checking nothing appears in the input line).

--- a/Tests/Harness/input-stomping/README.md
+++ b/Tests/Harness/input-stomping/README.md
@@ -30,7 +30,7 @@ presses Enter and prints what the server made of the input.
 |------|---------|------------------------------------|
 | MUD client (Mudlet, TinTin++; answers DO ECHO) | `python3 stomp.py MUD` | `\r\x1b[2K` + message + real prompt line + `hello wor` |
 | Web terminal (raw TCP, `X-Client:Web`, keystrokes streamed) | `python3 stomp.py WEB` | same as MUD; typing must echo (`bytes while typing` = `hello wor`) |
-| SyncTerm / CP437 (TTYPE reply `SYNCTERM`) | `python3 stomp.py SYNCTERM` | same as MUD. Known gap: the scripted TTYPE reply does not currently trigger CP437 detection in `ProbeTtypeAsync`, so this case exercises the MUD path; CP437 translation is the shared `WriteRawAnsi` path |
+| SyncTerm / CP437 (TTYPE reply `SYNCTERM`, answered after the server's TTYPE SEND) | `python3 stomp.py SYNCTERM` | same as MUD, and the box art after Enter must be CP437 bytes (the case prints a check) |
 | Desktop / Steam / BBS door client (AUTH on TCP, whole lines, local echo) | `python3 stomp.py DESKTOP` | `\r\n` + message + real prompt line, no typed text, no erase. Server side only: the real client's re-echo of its own buffer (OnlinePlaySystem) is hand-verified, not driven here |
 | SSH through `--mud-relay` under a real PTY | `python3 relay_stomp.py` | same as MUD; PTY attrs must show ICANON and ECHO off |
 
@@ -38,6 +38,14 @@ Pass criteria for every case: the message is on its own line, the prompt that wa
 on screen before the message is redrawn exactly, and the typed text appears at most
 once (exactly once on echo transports, zero times on the desktop path, where the
 client re-shows its own buffer).
+
+Two more cases were run by hand for v1.0.6 and are worth repeating when the relay
+or the desktop client changes: an SSH terminal through a real sshd ForceCommand
+relay, and the real desktop binary through the same SSH gateway. A throwaway
+Docker image (dotnet runtime + openssh-server, `usurper:play`, ForceCommand
+`--mud-relay --mud-port 4999`, MUD server in the same container) is enough; drive
+the desktop binary under a PTY, choose Online, custom server, host 127.0.0.1,
+port 4000.
 
 The real web page can be driven too: run `web/ssh-proxy.js` with
 `MUD_MODE=1 MUD_PORT=4999 DB_PATH=/tmp/usurper-harness/test.db`, add your origin to

--- a/Tests/Harness/input-stomping/auto.py
+++ b/Tests/Harness/input-stomping/auto.py
@@ -1,0 +1,46 @@
+import sys, time, re, json, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from drive import Client, strip
+# rules: ordered (regex, reply); target: regex that ends the run
+RULES=[
+ (r"Choice:\s*$", "__LOGIN__"),
+ (r"Username:\s*$", "__USER__"),
+ (r"Choose a username:\s*$", "__USER__"),
+ (r"[Pp]assword:?\s*$", "__PASS__"),
+ (r"Character name:\s*$", "__CHAR__"),
+ (r"Your choice:\s*$", "__MENU__"),
+ (r"(?i)press any key|press enter|press space|continue\.\.\.|\[Enter\]", ""),
+ (r"\(Y/n\)\s*:?\s*$", "Y"),
+ (r"\(y/N\)\s*:?\s*$", "N"),
+ (r"(?i)\(y/n\)\s*:?\s*$", "Y"),
+ (r"(?i)choice\s*[:>]?\s*$", "__CHOICE__"),
+ (r"\[2\] Female:\s*$", "1"),
+ (r"(?i)name\s*:\s*$", "__CHAR__"),
+ (r">\s*$", ""),
+]
+def login_to_town(user, pw, char, target=r"Main Street >\s*$", header=None, telnet_reply=None, verbose=False, max_steps=60, register=False, client=None, telnet_reply_delay=0.0):
+    c=client or Client(header, telnet_reply, telnet_reply_delay); menu_sent=False; choices=[]
+    for step in range(max_steps):
+        buf=c.read(1.2); text=strip(buf)
+        if verbose and text.strip(): print("----"); print(text[-600:])
+        if re.search(target, text): return c
+        tail=text[-200:]
+        for pat, reply in RULES:
+            if re.search(pat, tail):
+                if reply=="__LOGIN__": reply="R" if register else "L"; register=False
+                elif reply=="__USER__": reply=user
+                elif reply=="__PASS__": reply=pw
+                elif reply=="__CHAR__": reply=char
+                elif reply=="__MENU__":
+                    if "Create new character" in text[-1500:]: reply="N"
+                    elif "Quick" in text[-700:] and "[Q]" in text[-700:]: reply="Q"
+                    else: reply="1"
+                elif reply=="__CHOICE__":
+                    reply = "Q" if ("Quick" in text[-700:] and "[Q]" in text[-700:]) else "1"
+                c.line(reply); choices.append((tail[-40:].strip(), reply)); break
+        else:
+            if not text.strip(): c.line("")
+    print("FAILED to reach target; choices:", choices); print(strip(c.log)[-1500:]); raise SystemExit(1)
+if __name__=='__main__':
+    c=login_to_town(sys.argv[1], sys.argv[2], sys.argv[3], verbose=False, register=(len(sys.argv)>4 and sys.argv[4]=="register"))
+    print("=== REACHED TOWN ==="); print(strip(c.log)[-800:])

--- a/Tests/Harness/input-stomping/drive.py
+++ b/Tests/Harness/input-stomping/drive.py
@@ -1,0 +1,45 @@
+import socket, sys, time, re, json, os
+def strip(b):
+    s=b.decode('utf-8','replace'); s=re.sub(r'\x1b\[[0-9;?]*[A-Za-z]','',s); s=re.sub(r'[\x00-\x08\x0b-\x1f\x7f]','',s); return s
+class Client:
+    def __init__(self, header=None, telnet_reply=None, telnet_reply_delay=0.0):
+        self.s=socket.create_connection(('127.0.0.1', int(os.environ.get('USURPER_PORT', '4999')))); self.s.settimeout(0.2); self.log=b''
+        if header:
+            for h in header: self.s.sendall(h.encode()+b'\n')
+        if telnet_reply:
+            # The server first waits ~500ms for an AUTH/X- header line, then sends its telnet
+            # negotiation. A reply that must answer the TTYPE probe has to arrive after that.
+            if telnet_reply_delay:
+                # wait for the server's TTYPE SEND (IAC SB TTYPE SEND IAC SE) before answering
+                end=time.time()+telnet_reply_delay+2.0; seen=b''
+                while time.time()<end and b'\xff\xfa\x18\x01\xff\xf0' not in seen:
+                    try: seen+=self.s.recv(65536)
+                    except socket.timeout: pass
+                self.log+=seen
+            self.s.sendall(telnet_reply)
+    def read(self, secs=1.0):
+        out=b''; end=time.time()+secs
+        while time.time()<end:
+            try:
+                d=self.s.recv(65536)
+                if not d: break
+                out+=d
+            except socket.timeout: pass
+        self.log+=out; return out
+    def expect(self, pat, secs=8.0):
+        buf=b''; end=time.time()+secs
+        while time.time()<end:
+            buf+=self.read(0.3)
+            if re.search(pat, strip(buf)): return buf
+        raise TimeoutError(f"expected {pat!r}; got:\n{strip(buf)[-1200:]}")
+    def send(self, text): self.s.sendall(text.encode())
+    def line(self, text): self.s.sendall(text.encode()+b'\r\n')
+def run(steps, header=None, telnet_reply=None, tail=1500):
+    c=Client(header, telnet_reply)
+    for pat, reply in steps:
+        buf=c.expect(pat)
+        if reply is None: print("=== matched", repr(pat)); print(strip(buf)[-tail:]); return c
+        c.line(reply)
+    return c
+if __name__=='__main__':
+    steps=json.loads(sys.argv[1]); run(steps)

--- a/Tests/Harness/input-stomping/ptyclient.py
+++ b/Tests/Harness/input-stomping/ptyclient.py
@@ -1,0 +1,31 @@
+import os, pty, sys, time, re, select, termios
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from drive import strip
+EXE=os.environ.get("USURPER_EXE", os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../../bin/Release/net8.0/UsurperReborn"))
+class PtyClient:
+    """Runs the relay under a real PTY (cooked mode by default), like sshd ForceCommand."""
+    def __init__(self, args, raw=False):
+        pid, fd = pty.fork()
+        if pid == 0:
+            os.execv(EXE, [EXE]+args)
+        self.pid, self.fd = pid, fd; self.log=b''
+        if raw:
+            attrs=termios.tcgetattr(fd); attrs[3] &= ~(termios.ICANON|termios.ECHO); termios.tcsetattr(fd, termios.TCSANOW, attrs)
+    def read(self, secs=1.0):
+        out=b''; end=time.time()+secs
+        while time.time()<end:
+            r,_,_=select.select([self.fd],[],[],0.1)
+            if r:
+                try: d=os.read(self.fd,65536)
+                except OSError: break
+                if not d: break
+                out+=d
+        self.log+=out; return out
+    def send(self, text): os.write(self.fd, text.encode())
+    def line(self, text): os.write(self.fd, text.encode()+b'\r')
+    def attrs(self):
+        a=termios.tcgetattr(self.fd); return {"ICANON": bool(a[3]&termios.ICANON), "ECHO": bool(a[3]&termios.ECHO)}
+if __name__=='__main__':
+    c=PtyClient(["--mud-relay","--mud-port","4999"])
+    print(strip(c.read(3.0))[-800:]); print(c.attrs())
+    os.kill(c.pid, 9)

--- a/Tests/Harness/input-stomping/relay_stomp.py
+++ b/Tests/Harness/input-stomping/relay_stomp.py
@@ -1,0 +1,22 @@
+import sys, time, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from auto import login_to_town
+from ptyclient import PtyClient
+from drive import strip
+typed = sys.argv[1] if len(sys.argv)>1 else "hello wor"
+relay = PtyClient(["--mud-relay","--mud-port","4999"])
+A = login_to_town("alpha","secret123","Alpha", client=relay)
+B = login_to_town("beta","secret123","Beta", telnet_reply=b'\xff\xfd\x01')
+A.read(1.0); B.read(1.0)
+print("[SSH relay] PTY attrs during game:", A.attrs())
+for ch in typed:
+    A.send(ch); time.sleep(0.05)
+echoed=A.read(1.5)
+print("  bytes on the SSH user's screen while typing:", repr(echoed))
+B.line("/tell Alpha ping")
+got=A.read(2.5)
+print("  bytes when tell arrived:", repr(got))
+A.line("")
+after=A.read(2.0)
+print("  after Enter:", repr(strip(after)[:200]))
+os.kill(relay.pid, 9)

--- a/Tests/Harness/input-stomping/stomp.py
+++ b/Tests/Harness/input-stomping/stomp.py
@@ -1,0 +1,37 @@
+import sys, time, re, os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from auto import login_to_town
+from drive import strip
+kind=sys.argv[1]  # MUD | WEB
+typed=sys.argv[2] if len(sys.argv)>2 else "hello wor"
+if kind=="MUD":
+    A=login_to_town("alpha","secret123","Alpha", telnet_reply=b'\xff\xfd\x01\xff\xfd\x03')   # DO ECHO, DO SGA
+elif kind=="WEB":
+    A=login_to_town("alpha","secret123","Alpha", header=["X-IP:127.0.0.1","X-Client:Web"])
+elif kind=="SYNCTERM":
+    # DO ECHO, DO SGA, WILL TTYPE, then TTYPE IS "SYNCTERM" so the server enables CP437
+    A=login_to_town("alpha","secret123","Alpha", telnet_reply=b'\xff\xfd\x01\xff\xfd\x03\xff\xfb\x18\xff\xfa\x18\x00SYNCTERM\xff\xf0', telnet_reply_delay=0.9)
+elif kind=="DESKTOP":
+    # Steam/desktop client: sends AUTH on the raw TCP stream, holds and echoes its own line locally,
+    # sends whole lines. The server must never echo or erase for it.
+    from drive import Client
+    c=Client(header=["AUTH:alpha:secret123:Steam:1.0.6"])
+    A=login_to_town("alpha","secret123","Alpha", client=c)
+B=login_to_town("beta","secret123","Beta", telnet_reply=b'\xff\xfd\x01')
+A.read(1.0); B.read(1.0)
+print(f"[{kind}] A at prompt; typing {typed!r} char by char")
+if kind=="DESKTOP":
+    echoed=A.read(1.5)   # desktop holds the line locally; nothing is sent until Enter
+else:
+    for ch in typed:
+        A.send(ch); time.sleep(0.05)
+    echoed=A.read(1.5)
+print("  bytes A received while typing:", repr(echoed))
+B.line(f"/tell Alpha ping")
+got=A.read(2.5)
+print("  B saw:", repr(strip(B.read(0.5))[-160:]))
+print("  bytes A received when tell arrived:", repr(got))
+A.line(typed if kind=="DESKTOP" else "")
+after=A.read(2.0)
+print("  after Enter, A got:", repr(strip(after)[:300]))
+if kind=="SYNCTERM": print("  CP437 box byte present:", b'\xc9' in after, " UTF-8 box present:", '\u2554'.encode() in after)

--- a/Tests/OutputLineTrackerTests.cs
+++ b/Tests/OutputLineTrackerTests.cs
@@ -64,6 +64,38 @@ public class OutputLineTrackerTests
     }
 
     [Fact]
+    public void Drops_osc_and_charset_escapes_whole()
+    {
+        var t = new OutputLineTracker();
+        t.Track("\x1b]0;Usurper Reborn\x07\x1b(BPrompt> ");
+        t.CurrentLine.Should().Be("Prompt> ");
+        t.Track("\x1b]2;title\x1b\\more");
+        t.CurrentLine.Should().Be("Prompt> more");
+    }
+
+    [Fact]
+    public void Front_trim_never_cuts_inside_an_escape_sequence()
+    {
+        var t = new OutputLineTracker();
+        t.Track(new string('x', 1020));
+        t.Track("\x1b[32mtail");
+        var line = t.CurrentLine;
+        line.Length.Should().BeLessOrEqualTo(1024 + 4);
+        line.Should().EndWith("\x1b[32mtail");
+        line.IndexOf('\x1b').Should().Be(line.IndexOf("\x1b[32m"), "no partial sequence may survive at the head");
+    }
+
+    [Fact]
+    public void Reset_clears_state_mid_sequence()
+    {
+        var t = new OutputLineTracker();
+        t.Track("abc\x1b[3");
+        t.Reset();
+        t.Track("1m");
+        t.CurrentLine.Should().Be("1m");
+    }
+
+    [Fact]
     public void Tracking_writer_sees_every_write_path_once()
     {
         var tracker = new OutputLineTracker();

--- a/Tests/OutputLineTrackerTests.cs
+++ b/Tests/OutputLineTrackerTests.cs
@@ -1,0 +1,96 @@
+using System.IO;
+using System.Text;
+using Xunit;
+using FluentAssertions;
+using UsurperRemake.Server;
+
+namespace UsurperReborn.Tests;
+
+/// <summary>
+/// v1.0.6 input-stomping fix: the tracked output line is what a mid-input redraw
+/// restores, so it must hold exactly the visible prompt (text plus colour codes)
+/// and nothing that would move the cursor or replay stale text.
+/// </summary>
+public class OutputLineTrackerTests
+{
+    [Fact]
+    public void Tracks_text_since_last_newline_and_keeps_colour_codes()
+    {
+        var t = new OutputLineTracker();
+        t.Track("Welcome\r\n\x1b[37m[\x1b[92m27hp\x1b[37m] Main Street > ");
+        t.CurrentLine.Should().Be("\x1b[37m[\x1b[92m27hp\x1b[37m] Main Street > ");
+    }
+
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r")]
+    [InlineData("\x1b[2J")]
+    [InlineData("\x1b[2K")]
+    public void Resets_on_newline_carriage_return_and_clears(string reset)
+    {
+        var t = new OutputLineTracker();
+        t.Track("old prompt > ");
+        t.Track(reset);
+        t.CurrentLine.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Drops_cursor_movement_but_not_the_text_around_it()
+    {
+        var t = new OutputLineTracker();
+        t.Track("\x1b[2J\x1b[H\x1b[1;36mTitle\x1b[0m");
+        t.CurrentLine.Should().Be("\x1b[1;36mTitle\x1b[0m", "ESC[H must not be replayed on redraw");
+    }
+
+    [Fact]
+    public void Suppress_ignores_writes_such_as_keystroke_echo()
+    {
+        var t = new OutputLineTracker();
+        t.Track("prompt > ");
+        t.Suppress = true;
+        t.Track("hello");
+        t.Suppress = false;
+        t.CurrentLine.Should().Be("prompt > ");
+    }
+
+    [Fact]
+    public void Incomplete_escape_sequence_is_not_exposed()
+    {
+        var t = new OutputLineTracker();
+        t.Track("abc\x1b[3");
+        t.CurrentLine.Should().Be("abc");
+        t.Track("2m");
+        t.CurrentLine.Should().Be("abc\x1b[32m");
+    }
+
+    [Fact]
+    public void Tracking_writer_sees_every_write_path_once()
+    {
+        var tracker = new OutputLineTracker();
+        using var ms = new MemoryStream();
+        using var w = new LineTrackingStreamWriter(ms, new UTF8Encoding(false), tracker) { AutoFlush = true };
+        w.Write('[');
+        w.Write("12hp");
+        w.Write(new[] { ']', ' ' }, 0, 2);
+        w.Write("Inn > ".AsSpan());
+        tracker.CurrentLine.Should().Be("[12hp] Inn > ");
+        w.WriteLine("gone");
+        tracker.CurrentLine.Should().BeEmpty();
+        Encoding.UTF8.GetString(ms.ToArray()).Should().Be("[12hp] Inn > gone" + w.NewLine);
+    }
+
+    [Theory]
+    [InlineData("MUD", "MUD", false)]
+    [InlineData("SSH;echo=1", "SSH", true)]
+    [InlineData("SSH;echo=0", "SSH", false)]
+    [InlineData("Steam;version=2", "Steam", false)]
+    [InlineData(" Web ; echo = 1 ", "Web", true)]
+    [InlineData("", "", false)]
+    [InlineData(null, "", false)]
+    public void Connection_type_parameters_are_stripped_and_echo_flag_read(string? input, string expectedType, bool expectedEcho)
+    {
+        var type = MudServer.ParseConnectionTypeParams(input, out bool echo);
+        type.Should().Be(expectedType);
+        echo.Should().Be(expectedEcho);
+    }
+}

--- a/web/ssh-proxy.js
+++ b/web/ssh-proxy.js
@@ -46,6 +46,15 @@ const DB_PATH = process.env.DB_PATH || '/var/usurper/usurper_online.db';
 // Connects to 4001 directly (bypassing sslh on 4000) so X-IP forwarding works.
 // Set MUD_MODE=0 to fall back to legacy SSH mode if needed.
 const MUD_MODE = process.env.MUD_MODE !== '0';
+
+// v1.0.6: index.html sends xterm's resize notification as a JSON control message
+// on the same websocket as keystrokes. Neither branch below ever handled it, so a
+// browser resize typed '{"type":"resize",...}' into the player's input buffer.
+function isResizeControlMessage(data) {
+  if (data == null || data.length === 0 || data.length > 200) return false;
+  const s = data.toString();
+  return s.startsWith('{"type":"resize"');
+}
 const MUD_HOST = process.env.MUD_HOST || '127.0.0.1';
 const MUD_PORT = parseInt(process.env.MUD_PORT || '4001', 10);
 const CACHE_TTL = 120000; // 2 minutes (uncached query takes ~20s with 275 players)
@@ -4103,6 +4112,7 @@ wss.on('connection', (ws, req) => {
 
     // WebSocket → TCP
     ws.on('message', (data) => {
+      if (isResizeControlMessage(data)) return;
       if (!tcp.destroyed) {
         tcp.write(data);
       }
@@ -4164,6 +4174,7 @@ wss.on('connection', (ws, req) => {
 
     // WebSocket data → SSH stdin
     ws.on('message', (data) => {
+      if (isResizeControlMessage(data)) return;
       if (sshStream) {
         sshStream.write(data);
       }


### PR DESCRIPTION
A message arriving mid-typing no longer destroys what the player typed. Full notes in `DOCS/RELEASE_NOTES_1.0.6.md`; Steam BBCode in `DOCS/STEAM_RELEASE_NOTES_1.0.6.txt`.

## Summary

Each transport was measured with a scripted client before any code changed (harness in `Tests/Harness/input-stomping`). Four different mechanisms:

- **Web**: the server never echoed for `X-Client:Web` and xterm.js never echoes locally, so web players were typing blind in game. Verified in a browser against the real page. Web now gets server echo like a MUD client.
- **SSH**: the relay read stdin through .NET's line-mode console reader, so the server never saw the text it erased. The relay now puts its PTY in raw mode (termios P/Invoke, `TerminalRawMode`), reads fd 0 directly, and asks for echo with `SSH;echo=1` in the AUTH type field. Old servers ignore the suffix.
- **MUD clients**: the redraw printed GetInput's prompt argument instead of the visible prompt. `OutputLineTracker` tracks the current output line and the redraw uses it.
- **Desktop/Steam/BBS door**: the server can never see their line, so it now delivers on a fresh line without erasing; the desktop client re-shows its buffer behind the prompt.

Also: no erase sequences for screen readers, redraw through the CP437 path, and the web proxy drops xterm's resize JSON that was being typed into the input buffer.

## Review

Design and both commits reviewed by the supervisor session; findings folded into 6010fa0 and 0bbe8e7.

## Tests

977 passing (16 new in `OutputLineTrackerTests` plus 3 follow-ups). Harness cases MUD, WEB, DESKTOP, SSH-under-PTY green; SYNCTERM runs but does not trigger CP437 detection; DESKTOP measures the server side only.
