### PR TITLE
Gear set bonuses apply to every character

### DIFF
--- a/DOCS/RELEASE_NOTES_1.1.0.md
+++ b/DOCS/RELEASE_NOTES_1.1.0.md
@@ -58,10 +58,9 @@ Agility and +4 weapon power.
 Two things to know. Sets count gear generated after this update; an item you
 found or bought before it does not know its family and will not count until it
 is replaced. Nobody had a set before, so this is a delayed start rather than a
-loss. And sets are for players only, including your saved character when it
-defends in the arena or while asleep. NPCs, companions, and the dungeon echo of
-yourself wear the same families and would have grown stronger everywhere at
-once; they stay as they are until they get their own pass. A Constitution bonus
-from a set also raises HP the usual way, on top of the HP figure listed.
+loss. And sets apply to everyone who wears the gear: NPCs, companions, your
+dungeon echo, and your saved character when it defends in the arena or while
+asleep all get the same bonuses you do. A Constitution bonus from a set also
+raises HP the usual way, on top of the HP figure listed.
 
 Not yet sets: Runed, Plate, Titan's, Dragon, and Holy. They are the next slice.

--- a/Scripts/Core/Character.cs
+++ b/Scripts/Core/Character.cs
@@ -1626,10 +1626,10 @@ public class Character
             item?.ApplyToCharacter(this);
         }
 
-        // v1.1: gear set bonuses, players and player snapshots (PvP defenders) only.
-        // Placed before the CON-to-HP line so a set CON bonus flows into MaxHP.
-        if (IsPlayer || IsPlayerSnapshot)
-            UsurperRemake.Systems.GearSetRegistry.Apply(this);
+        // v1.1: gear set bonuses, for every character. NPCs, companions, echoes and PvP
+        // snapshots wear the same families and get the same bonuses (maintainer decision,
+        // 2026-09-03). Placed before the CON-to-HP line so a set CON bonus flows into MaxHP.
+        UsurperRemake.Systems.GearSetRegistry.Apply(this);
 
         // Apply stat-based bonuses AFTER equipment (stats may have been modified)
         // Constitution bonus to HP
@@ -2446,9 +2446,6 @@ public class Character
     // Helper properties for commonly used calculations
     public bool IsAlive => HP > 0;
     public bool IsPlayer => AI == CharacterAI.Human;
-    /// <summary>v1.1: a player's saved character rebuilt for PvP/sleeper/arena use (PlayerCharacterLoader).
-    /// Runs with AI = Computer but must get the same gear set bonuses as the live player. Transient.</summary>
-    public bool IsPlayerSnapshot { get; set; }
     public bool IsNPC => AI == CharacterAI.Computer;
     // v0.65.1: append the optional family surname (set only on the player, via the
     // marriage ceremony). Name2 stays the stable identity key; this is the display layer.

--- a/Scripts/Systems/GearSetSystem.cs
+++ b/Scripts/Systems/GearSetSystem.cs
@@ -34,8 +34,8 @@ namespace UsurperRemake.Systems
     /// each generated item at creation (never on the localized display name, and never
     /// on a prefix parse: "Forged-Thread Cape" and "Cloak of Shadows" are not set pieces).
     /// Bonuses are applied in Character.RecalculateStats after the equipped-item loop,
-    /// for players and player snapshots only; NPCs and companions wear the same families
-    /// and are deliberately excluded until they get a design pass.
+    /// for every character: NPCs, companions, echoes and PvP snapshots wear the same
+    /// families and get the same bonuses (maintainer decision, 2026-09-03).
     /// Numbers are a first pass, tuned per level band, and are meant to be revisited
     /// with live data: modest at two pieces, meaningful at four, build-defining at six.
     /// The block runs before the Constitution-to-HP line, so a Constitution bonus also

--- a/Scripts/Systems/PlayerCharacterLoader.cs
+++ b/Scripts/Systems/PlayerCharacterLoader.cs
@@ -40,7 +40,6 @@ public static class PlayerCharacterLoader
             Gold = playerData.Gold,
             Poison = playerData.Poison,
             AI = CharacterAI.Computer,
-            IsPlayerSnapshot = !isEcho, // v1.1: PvP defenders get gear set bonuses; the dungeon ally echo is a companion and does not
             IsEcho = isEcho,
             // Restore base stats for RecalculateStats
             BaseStrength = playerData.BaseStrength > 0 ? playerData.BaseStrength : playerData.Strength,

--- a/Tests/GearSetTests.cs
+++ b/Tests/GearSetTests.cs
@@ -56,24 +56,25 @@ public class GearSetTests
     }
 
     [Fact]
-    public void Npcs_and_companions_get_nothing_from_the_same_gear()
+    public void Npcs_get_the_same_bonus_from_the_same_gear()
     {
+        // Maintainer decision 2026-09-03: sets apply to every character, not only players.
         var npc = new Character { AI = CharacterAI.Computer, Level = 30, BaseMaxHP = 100 };
         npc.RecalculateStats();
         long baseArm = npc.ArmPow;
         Wear(npc, ("Steel Helm", EquipmentSlot.Head), ("Steel Greaves", EquipmentSlot.Legs), ("Steel Gauntlets", EquipmentSlot.Hands), ("Steel Sabatons", EquipmentSlot.Feet));
-        npc.ArmPow.Should().Be(baseArm + 4, "four items, no set bonus");
-        npc.Strength.Should().Be(npc.BaseStrength);
+        npc.ArmPow.Should().Be(baseArm + 4 + 3, "four items plus the two-piece armor bonus");
+        npc.Strength.Should().Be(npc.BaseStrength + 4, "four-piece strength bonus");
     }
 
     [Fact]
-    public void A_player_snapshot_used_as_a_pvp_defender_gets_the_bonus()
+    public void A_bare_character_such_as_a_companion_or_pvp_snapshot_gets_the_bonus()
     {
-        var snap = new Character { AI = CharacterAI.Computer, IsPlayerSnapshot = true, Level = 30, BaseMaxHP = 100 };
-        snap.RecalculateStats();
-        long baseArm = snap.ArmPow;
-        Wear(snap, ("Steel Helm", EquipmentSlot.Head), ("Steel Greaves", EquipmentSlot.Legs));
-        snap.ArmPow.Should().Be(baseArm + 2 + 3);
+        var c = new Character { Level = 30, BaseMaxHP = 100 };
+        c.RecalculateStats();
+        long baseArm = c.ArmPow;
+        Wear(c, ("Steel Helm", EquipmentSlot.Head), ("Steel Greaves", EquipmentSlot.Legs));
+        c.ArmPow.Should().Be(baseArm + 2 + 3);
     }
 
     [Theory]


### PR DESCRIPTION
Maintainer decision: NPCs get set bonuses.

The player-and-snapshot gate around `GearSetRegistry.Apply` in `Character.RecalculateStats` is removed, so NPCs, companions, the dungeon echo, and PvP defenders wearing the same families get the same tiers a player does. The `IsPlayerSnapshot` flag that existed only for the gate is gone. Tests now assert that an NPC in four Steel pieces gains the two- and four-piece tiers and that a bare character gains the two-piece tier; the 1.1 draft notes say sets apply to everyone.

Balance note: NPCs equipped from shop-generated items carry a family, so some NPCs in the arena, dungeon, and world sim will grow stronger where their gear happens to form a set. Built-in catalog items and NPC-generated bag items carry no family, so most NPCs are unchanged until their gear is refreshed from generated stock.

1,005 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT1VB81uLs5VNysGendLKY
