### PR TITLE
NPC set outfitting follow-ups

### DIFF
--- a/Scripts/Data/EquipmentData.cs
+++ b/Scripts/Data/EquipmentData.cs
@@ -313,7 +313,9 @@ public static class EquipmentDatabase
         lock (_lock)
         {
             return _allEquipment.Values
-                .Where(e => e.Slot == slot && e.Value <= maxGold && e.Id < DynamicEquipmentStart
+                // Shop band by name, not by "has a Family": if built-ins ever gain families
+                // (say, to let low-level NPCs wear sets) this must not start handing them out.
+                .Where(e => e.Slot == slot && e.Value <= maxGold && IsShopGenerated(e.Id)
                             && !string.IsNullOrEmpty(e.Family) && families.Contains(e.Family))
                 .OrderByDescending(e => e.ArmorClass + e.WeaponPower + e.ShieldBonus)
                 .FirstOrDefault();

--- a/Scripts/Systems/NPCSpawnSystem.cs
+++ b/Scripts/Systems/NPCSpawnSystem.cs
@@ -821,8 +821,11 @@ namespace UsurperRemake.Systems
 
             // v1.1: some NPCs dress as gear-set wearers (GameConfig.NPCSetWearerChance). Pick a
             // set that has an affordable body piece and prefer its pieces in every slot.
-            // A wearer aims for a random tier (2, 4 or 6 pieces) so high-level NPCs are not all in
-            // full sets: the probe without this put every level-50+ wearer at six pieces.
+            // A wearer is capped at a random tier (2, 4 or 6 armour pieces) so high-level NPCs
+            // are not all in full sets: the probe without this put every level-50+ wearer at six.
+            // Whether the cap is reached is decided by affordability. The cap counts armour slots
+            // only; a matching weapon or off-hand (also drawn from the shop band) counts toward
+            // the set in the registry, so a wearer capped at four can show as six.
             GearSet? targetSet = null;
             int targetPieces = 0, setPieces = 0;
             if (random.NextDouble() < GameConfig.NPCSetWearerChance)


### PR DESCRIPTION
Review follow-ups to #124: the family-restricted query filters on the shop band explicitly (`IsShopGenerated`) instead of relying on built-ins having no family, and the tier target is documented as an armour-only cap decided by affordability. No behaviour change today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT1VB81uLs5VNysGendLKY