### PR TITLE
Combat: wounded teammates shield up or brace

### DIFF
--- a/Localization/en.json
+++ b/Localization/en.json
@@ -725,6 +725,7 @@
   "combat.companion_attacks": "{0} attacks {1}!",
   "combat.companion_hits": "{0} hits {1} for {2} damage!",
   "combat.companion_dodges": "{0} deftly dodges {1}'s attack!",
+  "combat.teammate_defends": "{0} braces for the next attack.",
   "combat.monster_attacks_companion": "{0} attacks {1}!",
   "combat.monster_hits_companion": "{2} damage gets through {1}'s defenses!",
   "combat.victory": "VICTORY!",

--- a/Localization/es.json
+++ b/Localization/es.json
@@ -725,6 +725,7 @@
   "combat.companion_attacks": "¡{0} ataca a {1}!",
   "combat.companion_hits": "¡{0} golpea a {1} por {2} de daño!",
   "combat.companion_dodges": "¡{0} esquiva ágilmente el ataque de {1}!",
+  "combat.teammate_defends": "{0} se prepara para el próximo ataque.",
   "combat.monster_attacks_companion": "¡{0} ataca a {1}!",
   "combat.monster_hits_companion": "¡{2} de daño atraviesa las defensas de {1}!",
   "combat.victory": "¡VICTORIA!",

--- a/Localization/fr.json
+++ b/Localization/fr.json
@@ -725,6 +725,7 @@
   "combat.companion_attacks": "{0} attaque {1} !",
   "combat.companion_hits": "{0} touche {1} pour {2} points de dégâts !",
   "combat.companion_dodges": "{0} esquive habilement l'attaque de {1} !",
+  "combat.teammate_defends": "{0} se prépare à encaisser la prochaine attaque.",
   "combat.monster_attacks_companion": "{0} attaque {1} !",
   "combat.monster_hits_companion": "{2} dégâts passent les défenses de {1}!",
   "combat.victory": "VICTOIRE !",

--- a/Localization/hu.json
+++ b/Localization/hu.json
@@ -725,6 +725,7 @@
   "combat.companion_attacks": "{0} megtámadja {1}-t!",
   "combat.companion_hits": "{0} eltalálja {1}-t, {2} sebzést okozva!",
   "combat.companion_dodges": "{0} ügyesen kitér {1} támadása elől!",
+  "combat.teammate_defends": "{0} felkészül a következő támadásra.",
   "combat.monster_attacks_companion": "{0} megtámadja {1}-t!",
   "combat.monster_hits_companion": "{2} sebzés átjut {1} védelmén!",
   "combat.victory": "GYŐZELEM!",

--- a/Localization/it.json
+++ b/Localization/it.json
@@ -725,6 +725,7 @@
   "combat.companion_attacks": "{0} attacca {1}!",
   "combat.companion_hits": "{0} colpisce {1} per {2} danni!",
   "combat.companion_dodges": "{0} schiva agilmente l'attacco di {1}!",
+  "combat.teammate_defends": "{0} si prepara a incassare il prossimo attacco.",
   "combat.monster_attacks_companion": "{0} attacca {1}!",
   "combat.monster_hits_companion": "{2} danni oltrepassano le difese di {1}!",
   "combat.victory": "VITTORIA!",

--- a/Scripts/Core/GameConfig.cs
+++ b/Scripts/Core/GameConfig.cs
@@ -1966,6 +1966,11 @@ public static partial class GameConfig
     // v1.2 (design item G): an NPC left to die while the player could have helped
     public const int AbandonPenaltySteps = 2;
     public const int AbandonCompanionLoyaltyPenalty = 15;
+    // v1.2: teammate self-preservation. Below the first, a companion or NPC teammate with no
+    // heal left prefers a defensive or evasive ability; below the second it braces (Defend,
+    // half damage) instead of attacking.
+    public const double TeammateDefensivePriorityHpPercent = 0.40;
+    public const double TeammateDefendHpPercent = 0.35;
     public const int RelationSuspicious = 80;
     public const int RelationAnger = 90;
     public const int RelationEnemy = 100;

--- a/Scripts/Core/GameConfig.cs
+++ b/Scripts/Core/GameConfig.cs
@@ -1971,6 +1971,7 @@ public static partial class GameConfig
     // half damage) instead of attacking.
     public const double TeammateDefensivePriorityHpPercent = 0.40;
     public const double TeammateDefendHpPercent = 0.35;
+    public const double TeammateEmergencySelfHealHpPercent = 0.30; // drink your own potion before triaging others
     public const int RelationSuspicious = 80;
     public const int RelationAnger = 90;
     public const int RelationEnemy = 100;

--- a/Scripts/Systems/CombatEngine.cs
+++ b/Scripts/Systems/CombatEngine.cs
@@ -18812,7 +18812,7 @@ public partial class CombatEngine
                 // Prefer AoE taunt (Thundering Roar), then single taunt
                 var tauntAbility = affordableAbilities.FirstOrDefault(a => a.SpecialEffect == "aoe_taunt")
                     ?? affordableAbilities.FirstOrDefault(a => a.SpecialEffect == "taunt");
-                if (tauntAbility != null)
+                if (tauntAbility != null && chosenAbility == null) // v1.2: never over a wounded teammate's shield
                     chosenAbility = tauntAbility;
             }
         }

--- a/Scripts/Systems/CombatEngine.cs
+++ b/Scripts/Systems/CombatEngine.cs
@@ -927,6 +927,10 @@ public partial class CombatEngine
                     teammate.MagicACBonus = 0;
                     teammate.DodgeNextAttack = false;
                     teammate.HasBloodlust = false;
+                    // v1.2: a brace on the round the last monster fell skips the round-end clear
+                    // (victory breaks the round loop), same leak the player's IsDefending had.
+                    teammate.IsDefending = false;
+                    teammate.ActiveStatuses.Remove(StatusEffect.Defending);
                     teammate.HasStatusImmunity = false;
                     teammate.StatusImmunityDuration = 0;
                     teammate.DeathsEmbraceActive = false;

--- a/Scripts/Systems/CombatEngine.cs
+++ b/Scripts/Systems/CombatEngine.cs
@@ -54,6 +54,31 @@ public partial class CombatEngine
     private readonly HashSet<Character> _lowAlliesAtTurnStart = new();
     private bool _ownerAidedThisTurn;
 
+    /// <summary>v1.2: abilities that keep a wounded teammate alive: Defense-type, evasive
+    /// sidesteps and smoke, and buffs that raise defense or reduce damage.</summary>
+    internal static List<ClassAbilitySystem.ClassAbility> SelectDefensiveAbilities(IEnumerable<ClassAbilitySystem.ClassAbility> abilities)
+    {
+        var evasive = new HashSet<string> { "dodge_next", "evasion", "smoke", "party_smoke_screen" };
+        return abilities.Where(a =>
+                a.Type == ClassAbilitySystem.AbilityType.Defense
+                || evasive.Contains(a.SpecialEffect)
+                || (a.Type == ClassAbilitySystem.AbilityType.Buff && a.DefenseBonus > 0))
+            .ToList();
+    }
+
+    /// <summary>v1.2: a teammate below TeammateDefendHpPercent with no heal or defensive ability
+    /// left braces for the round (half incoming damage) instead of swinging. Cleared at round end
+    /// like the player's Defend.</summary>
+    internal bool TryTeammateDefend(Character teammate)
+    {
+        if (teammate.IsDefending || teammate.MaxHP <= 0) return false;
+        if ((double)teammate.HP / teammate.MaxHP >= GameConfig.TeammateDefendHpPercent) return false;
+        teammate.IsDefending = true;
+        if (!teammate.ActiveStatuses.ContainsKey(StatusEffect.Defending))
+            teammate.ActiveStatuses[StatusEffect.Defending] = 1;
+        return true;
+    }
+
     /// <summary>Called as the combat owner's chosen action starts: which allies were below half
     /// HP, and whether the action was aid to an ally.</summary>
     internal void NoteOwnerTurn(Character actor, IEnumerable<Character>? teammates, CombatAction action)
@@ -6637,6 +6662,15 @@ public partial class CombatEngine
         // Check if teammate should use a class ability
         var abilityAction = await TryTeammateClassAbility(teammate, monsterList, result);
         if (abilityAction) return;
+        // v1.2: nothing left to heal or shield with and badly hurt: brace instead of swinging
+        if (TryTeammateDefend(teammate))
+        {
+            terminal.SetColor("cyan");
+            terminal.WriteLine(Loc.Get("combat.teammate_defends", teammate.DisplayName));
+            result.CombatLog.Add($"{teammate.DisplayName} braces for the next attack.");
+            await Task.Delay(GetCombatDelay(600));
+            return;
+        }
 
         // Otherwise, basic attack
         var (swings, windfuryProc) = GetAttackCount(teammate);
@@ -18019,6 +18053,15 @@ public partial class CombatEngine
         {
             return; // Ability was used
         }
+        // v1.2: nothing left to heal or shield with and badly hurt: brace instead of swinging
+        if (TryTeammateDefend(teammate))
+        {
+            terminal.SetColor("cyan");
+            terminal.WriteLine(Loc.Get("combat.teammate_defends", teammate.DisplayName));
+            result.CombatLog.Add($"{teammate.DisplayName} braces for the next attack.");
+            await Task.Delay(GetCombatDelay(600));
+            return;
+        }
 
         // Otherwise, attack the weakest monster
         var weakestMonster = monsters
@@ -18776,6 +18819,14 @@ public partial class CombatEngine
         }
 
         // Ability use chance: default 50%, overridden by spec
+        // v1.2: a wounded teammate reaches for a shield or a sidestep before anything else,
+        // and does not leave it to the use-chance roll.
+        if (chosenAbility == null && teammateHpPercent < GameConfig.TeammateDefensivePriorityHpPercent)
+        {
+            var lifeSavers = SelectDefensiveAbilities(affordableAbilities);
+            if (lifeSavers.Count > 0)
+                chosenAbility = lifeSavers.OrderByDescending(a => a.LevelRequired).First();
+        }
         int abilityUsePercent = 50;
         if (activeSpec != null)
             abilityUsePercent = (int)(activeSpec.AbilityUseChance * 100);
@@ -24434,6 +24485,16 @@ public partial class CombatEngine
             player.DelugeCooldown--;
 
         // Decrement teammate ability cooldowns
+        // v1.2: a teammate's Defend lasts one round, like the player's
+        if (currentTeammates != null)
+        {
+            foreach (var tm in currentTeammates)
+            {
+                if (!tm.IsDefending) continue;
+                tm.IsDefending = false;
+                tm.ActiveStatuses.Remove(StatusEffect.Defending);
+            }
+        }
         foreach (var tcEntry in teammateCooldowns.Values)
         {
             var tcKeys = tcEntry.Keys.ToList();

--- a/Scripts/Systems/CombatEngine.cs
+++ b/Scripts/Systems/CombatEngine.cs
@@ -66,6 +66,9 @@ public partial class CombatEngine
             .ToList();
     }
 
+    internal static bool IsWoundedForDefense(Character c) =>
+        c.MaxHP > 0 && (double)c.HP / c.MaxHP < GameConfig.TeammateDefensivePriorityHpPercent;
+
     /// <summary>v1.2: a teammate below TeammateDefendHpPercent with no heal or defensive ability
     /// left braces for the round (half incoming damage) instead of swinging. Cleared at round end
     /// like the player's Defend.</summary>
@@ -6659,6 +6662,8 @@ public partial class CombatEngine
         var healAction = await TryTeammateHealAction(teammate, allPartyMembers, result);
         if (healAction) return;
 
+        // v1.2: wounded, a teammate looks for a shield before it casts an attack spell
+        if (IsWoundedForDefense(teammate) && await TryTeammateClassAbility(teammate, monsterList, result)) return;
         // Check if teammate should cast an offensive spell
         var spellAction = await TryTeammateOffensiveSpell(teammate, monsterList, result);
         if (spellAction) return;
@@ -18044,6 +18049,11 @@ public partial class CombatEngine
             return; // Healing action was taken
         }
 
+        // v1.2: wounded, a teammate looks for a shield before it casts an attack spell
+        if (IsWoundedForDefense(teammate) && await TryTeammateClassAbility(teammate, monsters, result))
+        {
+            return;
+        }
         // Check if teammate should cast an offensive spell
         var spellAction = await TryTeammateOffensiveSpell(teammate, monsters, result);
         if (spellAction)
@@ -18144,6 +18154,15 @@ public partial class CombatEngine
         // Check if teammate can heal with spells (any class with mana and healing spells)
         bool canHealWithSpells = teammate.Mana > 10 && GetBestHealSpell(teammate) != null;
         bool hasPotion = teammate.Healing > 0;
+
+        // v1.2: about to die, a teammate drinks its own potion first; the old order potioned the
+        // most injured party member and returned, so a teammate at 20 percent handed its last
+        // potion to an ally at 45 and kept fighting.
+        double ownPercent = (double)teammate.HP / Math.Max(1, teammate.MaxHP);
+        if (hasPotion && ownPercent < GameConfig.TeammateEmergencySelfHealHpPercent)
+        {
+            return await TeammateHealWithPotion(teammate, teammate, result);
+        }
 
         // Classes that prioritize healing
         bool isHealerClass = teammate.Class == CharacterClass.Cleric ||
@@ -18770,6 +18789,14 @@ public partial class CombatEngine
 
         // PRIORITY 1: Tank role — taunt immediately if no monsters are taunted
         // Tanks should establish aggro before anything else. This skips the 50% gate.
+        // v1.2: a wounded teammate reaches for a shield or a sidestep before anything else,
+        // ahead of the tank's taunt and of the use-chance roll.
+        if (teammateHpPercent < GameConfig.TeammateDefensivePriorityHpPercent)
+        {
+            var lifeSavers = SelectDefensiveAbilities(affordableAbilities);
+            if (lifeSavers.Count > 0)
+                chosenAbility = lifeSavers.OrderByDescending(a => a.LevelRequired).First();
+        }
         bool isTankClass = teammate.Class == CharacterClass.Warrior || teammate.Class == CharacterClass.Paladin
             || teammate.Class == CharacterClass.Barbarian;
         bool isTankCompanion = teammate.IsCompanion && teammate.CompanionId.HasValue &&
@@ -18823,14 +18850,6 @@ public partial class CombatEngine
         }
 
         // Ability use chance: default 50%, overridden by spec
-        // v1.2: a wounded teammate reaches for a shield or a sidestep before anything else,
-        // and does not leave it to the use-chance roll.
-        if (chosenAbility == null && teammateHpPercent < GameConfig.TeammateDefensivePriorityHpPercent)
-        {
-            var lifeSavers = SelectDefensiveAbilities(affordableAbilities);
-            if (lifeSavers.Count > 0)
-                chosenAbility = lifeSavers.OrderByDescending(a => a.LevelRequired).First();
-        }
         int abilityUsePercent = 50;
         if (activeSpec != null)
             abilityUsePercent = (int)(activeSpec.AbilityUseChance * 100);
@@ -19325,6 +19344,7 @@ public partial class CombatEngine
                         if (monster.IsBoss)
                             actualDmg = Math.Max(actualDmg, (long)(monster.Level * 1.5));
                         actualDmg = CapTeammateDamageInOldGodFight(companion, actualDmg);
+                        if (companion.IsDefending) actualDmg = Math.Max(1, actualDmg / 2); // v1.2: brace covers specials too
                         companion.HP = Math.Max(0, companion.HP - actualDmg);
                         terminal.WriteLine($"{companion.DisplayName} takes {actualDmg} damage!", "red");
                         result.CombatLog.Add($"{monster.Name} uses {abilityName} on {companion.DisplayName} for {actualDmg}");
@@ -19356,6 +19376,7 @@ public partial class CombatEngine
                         if (monster.IsBoss)
                             dmg = Math.Max(dmg, (long)(monster.Level * 1.5));
                         dmg = CapTeammateDamageInOldGodFight(companion, dmg);
+                        if (companion.IsDefending) dmg = Math.Max(1, dmg / 2); // v1.2: brace covers life drain too
                         companion.HP = Math.Max(0, companion.HP - dmg);
                         if (abilityResult.LifeStealPercent > 0)
                         {
@@ -19853,7 +19874,9 @@ public partial class CombatEngine
                 });
                 terminal.WriteLine($"  {Loc.Get("combat.ally_death_could_have_helped", npc.DisplayName)}", "yellow");
             }
-            wasPermadeath = WorldSimulator.Instance?.MarkNPCDead(worldNpc, GameConfig.PermadeathChancePlayerKill,
+            // v1.2: an ally who dies in the player's party rolls the team rate (2 percent), not
+            // the "player killed an NPC" rate (8 percent) this passed since v0.42.
+            wasPermadeath = WorldSimulator.Instance?.MarkNPCDead(worldNpc, GameConfig.PermadeathChanceDungeonTeam,
                 killerName, deathLocation) ?? false;
             worldNpc.IsInConversation = savedEngaged;
             worldNpc.Team = savedTeam;

--- a/Tests/TeammateDefenseTests.cs
+++ b/Tests/TeammateDefenseTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using UsurperRemake;
+using UsurperRemake.Systems;
+using Xunit;
+
+namespace UsurperReborn.Tests;
+
+/// <summary>
+/// v1.2: companions and NPC teammates look after themselves. Below 40 percent HP the ability
+/// picker reaches for a defensive or evasive ability first; below 35 percent with nothing left
+/// they brace (half damage for the round) instead of attacking; Defend clears at round end.
+/// </summary>
+[Collection("SharedGameSingletons")]
+public class TeammateDefenseTests
+{
+    private static Character Teammate(long hp, long maxHp = 100) => new Character
+    {
+        Name2 = "Mira", Class = CharacterClass.Cleric, Race = CharacterRace.Elf, HP = hp, MaxHP = maxHp,
+    };
+
+    private static ClassAbilitySystem.ClassAbility Ability(string id, ClassAbilitySystem.AbilityType type, string effect = "", int defense = 0, int level = 1) =>
+        new() { Id = id, Name = id, Type = type, SpecialEffect = effect, DefenseBonus = defense, LevelRequired = level };
+
+    [Fact]
+    public void DefensiveSelection_KeepsShieldsSidestepsAndDefensiveBuffs_DropsAttacks()
+    {
+        var pool = new List<ClassAbilitySystem.ClassAbility>
+        {
+            Ability("power_strike", ClassAbilitySystem.AbilityType.Attack),
+            Ability("shield_wall", ClassAbilitySystem.AbilityType.Defense),
+            Ability("evasive_roll", ClassAbilitySystem.AbilityType.Utility, effect: "dodge_next"),
+            Ability("smoke_bomb", ClassAbilitySystem.AbilityType.Utility, effect: "smoke"),
+            Ability("war_cry", ClassAbilitySystem.AbilityType.Buff, defense: 0),
+            Ability("stone_skin", ClassAbilitySystem.AbilityType.Buff, defense: 8),
+            Ability("hex", ClassAbilitySystem.AbilityType.Debuff),
+        };
+        CombatEngine.SelectDefensiveAbilities(pool).Select(a => a.Id)
+            .Should().BeEquivalentTo(new[] { "shield_wall", "evasive_roll", "smoke_bomb", "stone_skin" });
+    }
+
+    [Fact]
+    public void Defend_TriggersBelowTheThreshold_OnceOnly()
+    {
+        var engine = new CombatEngine();
+        var tm = Teammate(30);
+        engine.TryTeammateDefend(tm).Should().BeTrue();
+        tm.IsDefending.Should().BeTrue();
+        tm.ActiveStatuses.Should().ContainKey(StatusEffect.Defending);
+        engine.TryTeammateDefend(tm).Should().BeFalse("already bracing this round");
+    }
+
+    [Fact]
+    public void Defend_DoesNotTrigger_WhenHealthy()
+    {
+        var engine = new CombatEngine();
+        engine.TryTeammateDefend(Teammate(50)).Should().BeFalse("half health is not desperate");
+        engine.TryTeammateDefend(Teammate(35)).Should().BeFalse("the threshold is strictly below 35 percent");
+        engine.TryTeammateDefend(Teammate(34)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Defend_ClearsAtRoundEnd()
+    {
+        var engine = new CombatEngine();
+        var tm = Teammate(20);
+        engine.TryTeammateDefend(tm).Should().BeTrue();
+        var field = typeof(CombatEngine).GetField("currentTeammates", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        field.SetValue(engine, new List<Character> { tm });
+        var owner = new Character { Name2 = "Hero", Class = CharacterClass.Warrior, Race = CharacterRace.Human, HP = 100, MaxHP = 100 };
+        typeof(CombatEngine).GetMethod("ProcessEndOfRoundAbilityEffects", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
+            .Invoke(engine, new object[] { owner });
+        tm.IsDefending.Should().BeFalse();
+        tm.ActiveStatuses.Should().NotContainKey(StatusEffect.Defending);
+    }
+}

--- a/Tests/TeammateDefenseTests.cs
+++ b/Tests/TeammateDefenseTests.cs
@@ -100,3 +100,36 @@ public class TeammateDefenseTests
         tm.ActiveStatuses.Should().NotContainKey(StatusEffect.Defending);
     }
 }
+
+public class TeammateDefensePriorityTests
+{
+    [Fact]
+    public void WoundedForDefense_IsStrictlyBelowForty()
+    {
+        var c = new Character { HP = 40, MaxHP = 100 };
+        CombatEngine.IsWoundedForDefense(c).Should().BeFalse();
+        c.HP = 39;
+        CombatEngine.IsWoundedForDefense(c).Should().BeTrue();
+        c.MaxHP = 0;
+        CombatEngine.IsWoundedForDefense(c).Should().BeFalse("a zero max HP is not a wound");
+    }
+
+    [Fact]
+    public void AllyPermadeath_UsesTheTeamRate()
+    {
+        // An ally who dies beside the player is priced as "died with team", not "player killed an NPC".
+        string src = System.IO.File.ReadAllText(System.IO.Path.Combine(RepoRoot(), "Scripts", "Systems", "CombatEngine.cs"));
+        int i = src.IndexOf("private async Task HandleNpcTeammateDeath(", System.StringComparison.Ordinal);
+        string body = src.Substring(i, 4000);
+        body.Should().Contain("GameConfig.PermadeathChanceDungeonTeam");
+        body.Should().NotContain("GameConfig.PermadeathChancePlayerKill");
+        GameConfig.PermadeathChanceDungeonTeam.Should().BeLessThan(GameConfig.PermadeathChancePlayerKill);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new System.IO.DirectoryInfo(System.AppContext.BaseDirectory);
+        while (dir != null && !System.IO.File.Exists(System.IO.Path.Combine(dir.FullName, "usurper-reloaded.csproj"))) dir = dir.Parent;
+        return dir?.FullName ?? throw new System.IO.DirectoryNotFoundException("repo root");
+    }
+}

--- a/Tests/TeammateDefenseTests.cs
+++ b/Tests/TeammateDefenseTests.cs
@@ -61,6 +61,31 @@ public class TeammateDefenseTests
     }
 
     [Fact]
+    public async System.Threading.Tasks.Task Defend_DoesNotLeakIntoTheNextFight_WhenVictorySkipsTheRoundEnd()
+    {
+        // A brace on the round the last monster falls never sees the round-end clear (victory
+        // breaks the round loop). The next fight's per-combat teammate scrub must clear it, or the
+        // teammate enters every later fight already defending and never braces again.
+        var owner = new Character
+        {
+            Name2 = "Hero", Class = CharacterClass.Warrior, Race = CharacterRace.Human, Level = 10,
+            HP = 500, MaxHP = 500, BaseMaxHP = 500, Strength = 80, BaseStrength = 80, Defence = 40, BaseDefence = 40,
+            Dexterity = 30, BaseDexterity = 30, Agility = 25, BaseAgility = 25, Constitution = 30, BaseConstitution = 30,
+            CombatSpeed = CombatSpeed.Instant,
+        };
+        var tm = Teammate(100); tm.Level = 10; tm.Strength = 50; tm.BaseStrength = 50; tm.BaseMaxHP = 100;
+        tm.IsDefending = true; tm.ActiveStatuses[StatusEffect.Defending] = 1; // left over from the previous fight
+        var script = new System.IO.MemoryStream(System.Text.Encoding.UTF8.GetBytes(string.Concat(Enumerable.Repeat("A\n", 12)) + string.Concat(Enumerable.Repeat("P\n", 6))));
+        var term = new TerminalEmulator(script, new System.IO.MemoryStream());
+        var engine = new CombatEngine(term);
+        var rat = new Monster { Name = "Sewer Rat", Level = 1, HP = 1, MaxHP = 1, Strength = 1, Defence = 0, Experience = 5, Gold = 3 };
+        var result = await engine.PlayerVsMonsters(owner, new List<Monster> { rat }, new List<Character> { tm }, offerMonkEncounter: false);
+        result.Outcome.Should().Be(CombatOutcome.Victory);
+        tm.IsDefending.Should().BeFalse("the per-combat scrub must clear a brace left over from the last fight");
+        tm.ActiveStatuses.Should().NotContainKey(StatusEffect.Defending);
+    }
+
+    [Fact]
     public void Defend_ClearsAtRoundEnd()
     {
         var engine = new CombatEngine();

--- a/Tests/TeammateDefenseTests.cs
+++ b/Tests/TeammateDefenseTests.cs
@@ -133,3 +133,38 @@ public class TeammateDefensePriorityTests
         return dir?.FullName ?? throw new System.IO.DirectoryNotFoundException("repo root");
     }
 }
+
+[Collection("SharedGameSingletons")]
+public class TeammateTauntVersusShieldTests
+{
+    /// <summary>A wounded tank with a shield and a taunt both affordable, and no monster taunted,
+    /// must pick the shield: the taunt block may not overwrite the low-health choice.</summary>
+    [Fact]
+    public async System.Threading.Tasks.Task WoundedTank_PicksTheShield_NotTheTaunt()
+    {
+        var owner = new Character { Name2 = "Hero", Class = CharacterClass.Warrior, Race = CharacterRace.Human, Level = 20, HP = 300, MaxHP = 300 };
+        var tank = new Character
+        {
+            Name2 = "Aldric", Class = CharacterClass.Paladin, Race = CharacterRace.Human, Level = 20,
+            HP = 30, MaxHP = 100, CurrentCombatStamina = 100, Mana = 0, MaxMana = 0,
+        };
+        tank.EquippedItems[EquipmentSlot.OffHand] = EquipmentDatabase.GetShields().First().Id; // Shield Wall and Aura of Protection require a shield
+        var term = new TerminalEmulator(new System.IO.MemoryStream(), new System.IO.MemoryStream());
+        var engine = new CombatEngine(term);
+        var flags = System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance;
+        typeof(CombatEngine).GetField("_combatOwner", flags)!.SetValue(engine, owner);
+        typeof(CombatEngine).GetField("currentPlayer", flags)!.SetValue(engine, owner);
+        typeof(CombatEngine).GetField("currentTeammates", flags)!.SetValue(engine, new List<Character> { tank });
+        var monsters = new List<Monster> { new Monster { Name = "Ogre", Level = 15, HP = 400, MaxHP = 400, Strength = 30 } };
+        var result = new CombatResult { Player = owner, Monsters = monsters, Teammates = new List<Character> { tank }, CombatLog = new List<string>() };
+
+        var method = typeof(CombatEngine).GetMethod("TryTeammateClassAbility", flags)!;
+        bool used = await (System.Threading.Tasks.Task<bool>)method.Invoke(engine, new object[] { tank, monsters, result })!;
+        used.Should().BeTrue("a level-20 Paladin at 30 percent has shields and a taunt affordable");
+
+        var cooldowns = (Dictionary<string, Dictionary<string, int>>)typeof(CombatEngine).GetField("teammateCooldowns", flags)!.GetValue(engine)!;
+        var mine = cooldowns.Values.Single();
+        mine.Keys.Should().Contain(k => k == "aura_of_protection" || k == "shield_wall", "the shield was used");
+        mine.Keys.Should().NotContain("thundering_roar", "a taunt draws more hits onto a teammate who is already at 30 percent");
+    }
+}


### PR DESCRIPTION
From a player report about companions soaking hits. Targeting is class-role weighted by design (tanks 160 to 180, Assassin 70), so a fighting-class companion beside an Assassin takes about two of three attacks, and being wounded raises their weight again. The teammate AI already drank its own potions and cast heals; it had no self-preservation once those ran out.

- Below 40 percent HP the ability picker prefers a defensive or evasive ability (Defense-type, dodge and smoke effects, buffs with a defense bonus), ahead of the tank taunt, ahead of any attack spell, and before the use-chance roll.
- Below 35 percent with nothing left, the teammate braces for the round: half incoming damage, now on ordinary hits, monster special attacks, and life drain alike, instead of attacking. Clears at round end and in the per-combat scrub (a brace on the round the last monster fell used to leak into every later fight).
- Below 30 percent a teammate drinks its own potion before triaging others; the old order handed its last potion to a slightly less injured ally.
- An NPC ally who dies in the player's party rolls the 2 percent "died with team" permadeath rate instead of the 8 percent "player killed an NPC" rate it has passed since v0.42.
- Both the single-monster and multi-monster teammate paths. One new line in five languages. Seven tests.

Reviewed by the supervisor (GO on the first three commits) with the last commit's gaps found jointly by Codex and the supervisor during the survivability brainstorm. Gate green at 1,081.