### PR TITLE
World boss line on Main Street only

### DIFF
--- a/Scripts/Locations/BaseLocation.cs
+++ b/Scripts/Locations/BaseLocation.cs
@@ -850,8 +850,9 @@ public abstract class BaseLocation
                 terminal.WriteLine($"*** {Loc.Get("base.system_message")}: {broadcast} ***", "bright_red");
             }
 
-            // v1.1.4: one world boss status line (countdown before, live status during), from the tick's snapshot
-            if (UsurperRemake.BBS.DoorMode.IsOnlineMode && currentPlayer.Level >= GameConfig.WorldBossMinLevel)
+            // v1.1.4: one world boss status line (countdown before, live status during), from the tick's snapshot.
+            // v1.1.6: on Main Street only; on every screen it was spam.
+            if (LocationId == GameLocation.MainStreet && UsurperRemake.BBS.DoorMode.IsOnlineMode && currentPlayer.Level >= GameConfig.WorldBossMinLevel)
             {
                 var bossLine = WorldBossSystem.Instance.TownLine();
                 if (bossLine != null)


### PR DESCRIPTION
The world boss countdown and live status line was drawn by the shared location base, so every screen carried it. Now Main Street only. No behaviour change otherwise; `/boss` and the mail, news, Discord, and hour-before notices are untouched.

Gate 1,150 passing. Reaches the public server on the next release deploy.