### PR TITLE
Release 1.1.6

### DIFF
--- a/DOCS/release-notes/README.md
+++ b/DOCS/release-notes/README.md
@@ -3,6 +3,7 @@
 One file per version, newest first. Steam-formatted copies (BBCode) are in
 `steam/`. The GitHub release for each tag carries the same text.
 
+- [v1.1.6](RELEASE_NOTES_1.1.6.md)
 - [v1.1.5](RELEASE_NOTES_1.1.5.md)
 - [v1.1.4](RELEASE_NOTES_1.1.4.md)
 - [v1.1.3](RELEASE_NOTES_1.1.3.md)

--- a/DOCS/release-notes/RELEASE_NOTES_1.1.6.md
+++ b/DOCS/release-notes/RELEASE_NOTES_1.1.6.md
@@ -1,0 +1,17 @@
+# Usurper Reborn v1.1.6
+
+A small release to get one fix onto the server.
+
+## Fixed
+
+- **The world boss line is on Main Street only.** The countdown before the
+  boss and the live status during it were drawn on every screen in town, the
+  shops and the dungeon entrance included, which was spam. Now it is one line
+  in one place. `/boss` still shows the countdown or the status from anywhere,
+  and the mail, news, Discord post, and hour-before call are unchanged, so a
+  player who wakes at the Inn, at home, or at the castle and never passes
+  Main Street still hears about the boss.
+
+## Tests
+
+1,150 passing, unchanged.

--- a/DOCS/release-notes/steam/STEAM_RELEASE_NOTES_1.1.6.txt
+++ b/DOCS/release-notes/steam/STEAM_RELEASE_NOTES_1.1.6.txt
@@ -1,0 +1,3 @@
+[h1]Usurper Reborn 1.1.6[/h1]
+
+A small one. The world boss countdown and status line was showing on every screen in town, which was spam. It is on Main Street only now. /boss still shows it from anywhere, and the mail, the news, Discord, and the call an hour before are unchanged.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## A Persistent Online Text RPG with a Living World
 
-**v1.1.5 "Regalia"** | **FREE AND OPEN SOURCE** | **GPL v2**
+**v1.1.6 "Regalia"** | **FREE AND OPEN SOURCE** | **GPL v2**
 
 130+ autonomous NPCs wake up, go to work, visit taverns, fall in love, get married, have children, age, and eventually die of old age, all while you're offline. Log back in, read the news feed, and discover that the blacksmith married the barmaid, the king was assassinated, or a new generation just came of age. The world doesn't wait for you.
 
@@ -282,6 +282,7 @@ The game ships small patches frequently. Each version has a dedicated release no
 - **v1.1.1:** a bug pass. Five review agents each took a domain of the codebase and about seventy findings were verified and fixed: NPCs losing their innate power on load, the world simulator editing the wrong player's relationships, a restored character unable to save, one player's autosave starving everyone else's, the Black Market re-rolling on relog, a closed connection spinning the server, bank and gambling exploits, buffs consumed a fight early, and raw placeholders in the text. See `DOCS/release-notes/RELEASE_NOTES_1.1.1.md`.
 - **v1.1.2:** seven of the eight open design items, each designed twice (Codex and Claude), reconciled against the code, and reviewed before implementation: grouped followers get their own cooldowns and a real death; haggling finally has a way in and its attempts persist; the bank vault is one persisted reserve per world, atomic online; relationships cool with neglect measured in days you were present; NPCs left to die while you held a heal remember it; ability and spell numbers are moddable from `GameData/`; the two intimacy lines that really dropped a name are fixed. Docker stack refreshed and verified. See `DOCS/release-notes/RELEASE_NOTES_1.1.2.md`.
 - **v1.1.3:** party survivability. Wounded allies shield up, brace (half damage on ordinary hits, specials, and life drain), and drink their own potion first; NPC allies who die in your party roll the 2 percent team permadeath rate they were always meant to; three stances per ally (Aggressive, Balanced, Cautious) set from the dungeon party menu or the Inn and saved with the character; monsters no longer prefer a wounded target and an ally's brace no longer pulls hits unless it is Aggressive; a shared potion belt (off by default, two loans per fight, never the player's last three), give-a-number, and the one-personal-potion rule; a fight summary per ally, a warning before a voluntary fight with an ally below 30 percent, and a floor guard that offers Cautious to an ally eleven levels behind. Planned by a council of Codex, a Claude design agent, and the supervisor session in `DOCS/PARTY_SURVIVABILITY_PLAN.md`; the downed state is the next release.
+- **v1.1.6:** the world boss town line shows on Main Street only; it was on every screen.
 - **v1.1.5:** the world boss, redone, second half: the fight. The boss's random ability roll is gone. Every couple of minutes it telegraphs its next move from a fixed cycle and the round shows it with its answer and its cost: a Strike is yours to Brace (a tenth of your health) or take (three tenths and its status); a Channel is everyone's to Interrupt, and enough interrupts before it lands break it and stagger the boss so every blow lands half again as hard, while an unbroken one lands on everyone fighting, halved for the braced, and a heal channel heals the boss. The boss focuses whoever is hurting it most, hitting them half again as hard and everyone else half as hard, and you can Challenge it to take that focus. The round screen is under twenty rows: the boss, you, who is fighting beside you (your group first), the telegraph, and a one-line menu; other fighters see your answers. The second half of `DOCS/WORLD_BOSS_PLAN.md`.
 - **v1.1.4:** the world boss, redone, first half. It comes every evening at 8 PM Eastern whether anyone is online or not, chosen to suit the median level of the last week's players, with a countdown on the town screen, mail to everyone active, news, Discord, and a call an hour before; it withdraws with its wounds if it survives its three-hour window and returns for up to three nights. Its health is a three-fighter budget instead of a population multiplier under the 2.25 difficulty scale (462 thousand for the smallest boss with two online); it meets a lower-level player at their level; blows are capped per round; the one-session lock and the unavoidable aura are gone; a boss left alone heals. Rewards by effort at the player's own level, worth about a dungeon hour, items by contribution, a quarter share on a withdrawal, settled once into a ledger and delivered by the player's own session online or offline, plus a day of extra experience for the realm. Planned by the council in `DOCS/WORLD_BOSS_PLAN.md`; the fight itself (telegraphs, interrupts, focus) is 1.1.5.
 - **v1.0.0 "Coronation":** the release. The Beta label comes off. Nothing in this version is a new subsystem; it is the accumulated result of the Countdown arc below plus a final hardening pass: the level-40 progression cliff closed end to end (XP taper through level 40, boss-flee desperation scaling, a guarded round after a failed flee, and the Hall of the Fallen memorial that hands a fallen character's heir a level-scaled inheritance), the login gate and permadeath cinematic fully localized in all five languages, AI-painted NPC portraits rendered at full fidelity for terminals that can carry them, and an external security audit answered in full. See `DOCS/release-notes/RELEASE_NOTES_1.0.0.md`.
@@ -336,7 +337,7 @@ Join Discord for discussions, feedback, and updates: **https://discord.gg/EZhwgD
 
 *"You are not a wave fighting the ocean. You ARE the ocean, dreaming of being a wave."*
 
-## Known Issues (v1.1.5)
+## Known Issues (v1.1.6)
 
 - Save files from the earliest alpha versions may not be fully compatible.
 - BBS FOSSIL mode not natively supported (use `--stdio` flag for FOSSIL-based BBSes via host pipe).
@@ -350,4 +351,4 @@ Join Discord for discussions, feedback, and updates: **https://discord.gg/EZhwgD
 
 ---
 
-**Status:** v1.1.5 "Regalia". The world is running. [Watch it live.](https://usurper-reborn.net)
+**Status:** v1.1.6 "Regalia". The world is running. [Watch it live.](https://usurper-reborn.net)

--- a/Scripts/Core/GameConfig.cs
+++ b/Scripts/Core/GameConfig.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 public static partial class GameConfig
 {
     // Version information
-    public const string Version = "1.1.5";
+    public const string Version = "1.1.6";
     public const string VersionName = "Regalia"; // 1.1 line: the gear and reward loop
 
     // v0.57.12: Alignment scale cap. Character.Chivalry and Character.Darkness setters clamp to [0, AlignmentCap]


### PR DESCRIPTION
Bump and notes only, to deploy #140 (the world boss town line on Main Street only). Gate 1,150 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT1VB81uLs5VNysGendLKY