### PR TITLE
Reforge the player's own copy of a weapon; language tests in the shared collection

### DIFF
--- a/Scripts/Core/Character.cs
+++ b/Scripts/Core/Character.cs
@@ -1552,6 +1552,26 @@ public class Character
     }
 
     /// <summary>
+    /// issue #112: the equipped item in a slot as this character's own copy. A weapon bought at the
+    /// shop and equipped at the counter carries the shop's shared template ID; anything that
+    /// rewrites its stats (the reforge) would rewrite the template for every player in the process
+    /// and be lost on restart, because template IDs are never saved as dynamic equipment. This
+    /// clones the template into a dynamic copy and re-points the slot, once. Loot already has its
+    /// own copy and is returned as is.
+    /// </summary>
+    public Equipment? EnsureOwnEquipmentCopy(EquipmentSlot slot)
+    {
+        if (!EquippedItems.TryGetValue(slot, out var id) || id <= 0) return null;
+        var current = EquipmentDatabase.GetById(id);
+        if (current == null) return null;
+        if (EquipmentDatabase.IsDynamic(id)) return current;
+        var copy = current.Clone();
+        EquipmentDatabase.RegisterDynamic(copy);
+        EquippedItems[slot] = copy.Id;
+        return copy;
+    }
+
+    /// <summary>
     /// Unequip item from a specific slot
     /// </summary>
     public Equipment? UnequipSlot(EquipmentSlot slot)

--- a/Scripts/Data/EquipmentData.cs
+++ b/Scripts/Data/EquipmentData.cs
@@ -106,6 +106,8 @@ public static class EquipmentDatabase
 
     // Dynamic equipment starts at high ID to avoid conflicts
     private const int DynamicEquipmentStart = 100000;
+    /// <summary>A per-copy item (loot, a registered clone); anything below is a shared template.</summary>
+    public static bool IsDynamic(int id) => id >= DynamicEquipmentStart;
     private static int _nextDynamicId = DynamicEquipmentStart;
     private static readonly object _lock = new object();
 

--- a/Scripts/Locations/WeaponShopLocation.cs
+++ b/Scripts/Locations/WeaponShopLocation.cs
@@ -1163,7 +1163,8 @@ public class WeaponShopLocation : BaseLocation
         WriteSectionHeader(Loc.Get("weapon_shop.reforge_title"), "bright_magenta");
         terminal.WriteLine("");
 
-        var weapon = currentPlayer.GetEquipment(EquipmentSlot.MainHand);
+        // issue #112: reforge the player's own copy, never the shop's shared template
+        var weapon = currentPlayer.EnsureOwnEquipmentCopy(EquipmentSlot.MainHand);
         if (weapon == null)
         {
             terminal.WriteLine(Loc.Get("weapon_shop.reforge_no_weapon"), "red");

--- a/Tests/DialogueEnhancerTests.cs
+++ b/Tests/DialogueEnhancerTests.cs
@@ -14,6 +14,8 @@ namespace UsurperReborn.Tests;
 /// base line preserved when no layer fires, and the recent-line cache
 /// not crashing on repeated calls.
 /// </summary>
+// issue #131: sets the static GameConfig.Language; never beside another class that reads it
+[Collection("SharedGameSingletons")]
 public class DialogueEnhancerTests
 {
     [Fact]

--- a/Tests/GameConfigTests.cs
+++ b/Tests/GameConfigTests.cs
@@ -6,6 +6,8 @@ namespace UsurperReborn.Tests;
 /// <summary>
 /// Unit tests for GameConfig constants and configuration
 /// </summary>
+// issue #131: sets the static GameConfig.Language; never beside another class that reads it
+[Collection("SharedGameSingletons")]
 public class GameConfigTests
 {
     [Fact]

--- a/Tests/ReforgeOwnCopyTests.cs
+++ b/Tests/ReforgeOwnCopyTests.cs
@@ -1,0 +1,86 @@
+using System.Linq;
+using FluentAssertions;
+using UsurperRemake;
+using Xunit;
+
+namespace UsurperReborn.Tests;
+
+/// <summary>
+/// issue #112: a reforge must touch the player's own copy of a weapon, never the shop's shared
+/// template, and a reforged weapon must survive unequip and re-equip with its rarity and stats.
+/// </summary>
+[Collection("SharedGameSingletons")]
+public class ReforgeOwnCopyTests
+{
+    private static Character Hero() => new Character
+    {
+        Name1 = "smith", Name2 = "Smith", Class = CharacterClass.Warrior, Race = CharacterRace.Human, Level = 20,
+        HP = 500, MaxHP = 500, Strength = 50, Defence = 30,
+    };
+
+    [Fact]
+    public void AShopWeaponEquippedAtTheCounter_GetsItsOwnCopyBeforeAReforge_AndTheTemplateIsUntouched()
+    {
+        var template = EquipmentDatabase.GetOneHandedWeapons().First(w => w.MinLevel <= 20 && !w.IsCursed);
+        int templateId = template.Id;
+        int templatePower = template.WeaponPower;
+        var rarity = template.Rarity;
+
+        var hero = Hero();
+        hero.EquipItem(template, EquipmentSlot.MainHand, out _).Should().BeTrue();
+        hero.EquippedItems[EquipmentSlot.MainHand].Should().Be(templateId, "the shop equips the template itself");
+        EquipmentDatabase.IsDynamic(templateId).Should().BeFalse();
+
+        var own = hero.EnsureOwnEquipmentCopy(EquipmentSlot.MainHand)!;
+        own.Id.Should().NotBe(templateId);
+        EquipmentDatabase.IsDynamic(own.Id).Should().BeTrue();
+        hero.EquippedItems[EquipmentSlot.MainHand].Should().Be(own.Id, "the slot points at the copy");
+        own.WeaponPower.Should().Be(templatePower);
+
+        // the reforge rewrites the copy; the template every other player shares does not move
+        own.WeaponPower = templatePower * 3;
+        own.Rarity = EquipmentRarity.Epic;
+        EquipmentDatabase.GetById(templateId)!.WeaponPower.Should().Be(templatePower);
+        EquipmentDatabase.GetById(templateId)!.Rarity.Should().Be(rarity);
+
+        hero.EnsureOwnEquipmentCopy(EquipmentSlot.MainHand)!.Id.Should().Be(own.Id, "a second call is a no-op on a copy");
+        hero.RecalculateStats();
+        hero.WeapPow.Should().Be(hero.BaseWeapPow + templatePower * 3, "the character wears the copy");
+    }
+
+    [Fact]
+    public void AReforgedWeapon_KeepsItsRarityAndStats_ThroughUnequipAndReequip()
+    {
+        var template = EquipmentDatabase.GetOneHandedWeapons().First(w => w.MinLevel <= 20 && !w.IsCursed);
+        var hero = Hero();
+        hero.EquipItem(template, EquipmentSlot.MainHand, out _).Should().BeTrue();
+        var own = hero.EnsureOwnEquipmentCopy(EquipmentSlot.MainHand)!;
+        own.WeaponPower = 77; own.StrengthBonus = 9; own.AgilityBonus = 4; own.ConstitutionBonus = 6;
+        own.BlockChance = 3; own.LifeSteal = 5; own.Rarity = EquipmentRarity.Rare;
+
+        var unequipped = hero.UnequipSlot(EquipmentSlot.MainHand)!;
+        var item = hero.ConvertEquipmentToLegacyItem(unequipped);
+        item.Rarity.Should().Be(EquipmentRarity.Rare, "the quality does not reset in the bag");
+        item.Attack.Should().Be(77);
+        item.Strength.Should().Be(9);
+        item.Agility.Should().Be(4);
+        item.BlockChance.Should().Be(3);
+        item.LootEffects.Should().Contain(((int)LootGenerator.SpecialEffect.Constitution, 6));
+        item.LootEffects.Should().Contain(((int)LootGenerator.SpecialEffect.LifeSteal, 5));
+
+        var back = Character.BuildEquipmentFromItem(item, EquipmentSlot.MainHand, WeaponHandedness.OneHanded, own.WeaponType);
+        back.Rarity.Should().Be(EquipmentRarity.Rare);
+        back.WeaponPower.Should().Be(77);
+        back.StrengthBonus.Should().Be(9);
+        back.AgilityBonus.Should().Be(4);
+        back.ConstitutionBonus.Should().Be(6);
+        back.BlockChance.Should().Be(3);
+        back.LifeSteal.Should().Be(5);
+    }
+
+    [Fact]
+    public void AnEmptySlot_HasNoCopyToMake()
+    {
+        Hero().EnsureOwnEquipmentCopy(EquipmentSlot.MainHand).Should().BeNull();
+    }
+}


### PR DESCRIPTION
Fixes #112. Fixes #131.

**#112.** The lossy unequip converter the report describes was replaced in v0.65.3; rarity, block, agility, Con and Int, and every enchant carry through unequip, trades, and saves. What remained: the reforge wrote into whatever object the equipped ID resolved to. A weapon bought at the shop and equipped at the counter keeps the shop's template ID, so on the online server one player's reforge rewrote that weapon for everyone wearing it and for the shop's listing, and the reforged stats vanished on restart. `Character.EnsureOwnEquipmentCopy` clones a template into a dynamic copy and re-points the slot before the reroll; loot already has its own copy. A new round-trip test covers reforge, unequip, and re-equip keeping rarity and stats.

**#131.** `GameConfigTests` and `DialogueEnhancerTests` set the static language; both now run in the `SharedGameSingletons` collection.

Gate 1,153 passing, up from 1,150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CT1VB81uLs5VNysGendLKY